### PR TITLE
Card and Trigger Fixes

### DIFF
--- a/cards/classic/mage/secret_ice_block.json
+++ b/cards/classic/mage/secret_ice_block.json
@@ -8,8 +8,8 @@
 	"description": "Secret: When your hero takes fatal damage, prevent it and become Immune this turn.",
 	"trigger": {
 		"class": "FatalDamageTrigger",
-		"targetedPlayer": "SELF",
-		"targetPlayer": "BOTH",
+		"targetPlayer": "SELF",
+		"sourcePlayer": "BOTH",
 		"targetEntityType": "HERO"
 	},
 	"spell": {
@@ -25,7 +25,7 @@
 				"target": "FRIENDLY_HERO",
 				"attribute": "IMMUNE",
 				"revertTrigger": {
-					"class": "TurnStartTrigger"
+					"class": "TurnEndTrigger"
 				}
 			}
 		]

--- a/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
+++ b/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
@@ -1306,9 +1306,7 @@ public class GameLogic implements Cloneable {
 		Player player = context.getPlayer(playerId);
 		log("Card {} has been moved from the HAND to the GRAVEYARD", card);
 		card.setLocation(CardLocation.GRAVEYARD);
-		if (card.getAttribute(Attribute.PASSIVE_TRIGGER) != null) {
-			removeSpelltriggers(card);
-		}
+		removeSpelltriggers(card);
 		player.getHand().remove(card);
 		player.getGraveyard().add(card);
 	}
@@ -1504,12 +1502,12 @@ public class GameLogic implements Cloneable {
 		player.getHero().getHeroPower().setUsed(0);
 		player.getHero().activateWeapon(true);
 		refreshAttacksPerRound(player.getHero());
-		drawCard(playerId, null);
 		for (Entity minion : player.getMinions()) {
 			minion.removeAttribute(Attribute.SUMMONING_SICKNESS);
 			refreshAttacksPerRound(minion);
 		}
 		context.fireGameEvent(new TurnStartEvent(context, player.getId()));
+		drawCard(playerId, null);
 		checkForDeadEntities();
 	}
 

--- a/src/main/java/net/demilich/metastone/game/spells/CardCostModifierSpell.java
+++ b/src/main/java/net/demilich/metastone/game/spells/CardCostModifierSpell.java
@@ -6,23 +6,23 @@ import java.util.Map;
 
 import net.demilich.metastone.game.GameContext;
 import net.demilich.metastone.game.Player;
-import net.demilich.metastone.game.cards.costmodifier.CardCostModifier;
 import net.demilich.metastone.game.entities.Entity;
 import net.demilich.metastone.game.spells.desc.SpellArg;
 import net.demilich.metastone.game.spells.desc.SpellDesc;
+import net.demilich.metastone.game.spells.desc.filter.EntityFilter;
 import net.demilich.metastone.game.spells.desc.manamodifier.CardCostModifierArg;
 import net.demilich.metastone.game.spells.desc.manamodifier.CardCostModifierDesc;
 import net.demilich.metastone.game.targeting.EntityReference;
 
 public class CardCostModifierSpell extends Spell {
 
-	public static SpellDesc create(CardCostModifier cardCostModifier) {
-		return create(null, cardCostModifier);
+	public static SpellDesc create(CardCostModifierDesc cardCostModifierDesc) {
+		return create(null, cardCostModifierDesc);
 	}
 
-	public static SpellDesc create(EntityReference target, CardCostModifier cardCostModifier) {
+	public static SpellDesc create(EntityReference target, CardCostModifierDesc cardCostModifierDesc) {
 		Map<SpellArg, Object> arguments = SpellDesc.build(CardCostModifierSpell.class);
-		arguments.put(SpellArg.CARD_COST_MODIFIER, cardCostModifier);
+		arguments.put(SpellArg.CARD_COST_MODIFIER, cardCostModifierDesc);
 		arguments.put(SpellArg.TARGET, target);
 		return new SpellDesc(arguments);
 	}
@@ -30,6 +30,7 @@ public class CardCostModifierSpell extends Spell {
 	@Override
 	protected void onCast(GameContext context, Player player, SpellDesc desc, Entity source, Entity target) {
 		CardCostModifierDesc manaModifierDesc = (CardCostModifierDesc) desc.get(SpellArg.CARD_COST_MODIFIER);
+		EntityFilter cardFilter = (EntityFilter) desc.get(SpellArg.CARD_FILTER);
 		if (manaModifierDesc.contains(CardCostModifierArg.TARGET)) {
 			// First, resolve the targets, so that you can get the current cards this affects.
 			// This spell SPECIFICALLY targets cards, even if those cards would change. So,
@@ -38,7 +39,9 @@ public class CardCostModifierSpell extends Spell {
 			List<Entity> cards = context.resolveTarget(player, source, (EntityReference) manaModifierDesc.get(CardCostModifierArg.TARGET));
 			List<Integer> cardIds = new ArrayList<Integer>();
 			for (Entity card : cards) {
-				cardIds.add(card.getId());
+				if (cardFilter == null || cardFilter.matches(context, player, card)) {
+					cardIds.add(card.getId());
+				}
 			}
 			manaModifierDesc = manaModifierDesc.removeArg(CardCostModifierArg.TARGET);
 			manaModifierDesc = manaModifierDesc.addArg(CardCostModifierArg.CARD_IDS, cardIds);

--- a/src/main/java/net/demilich/metastone/game/spells/CopyCardSpell.java
+++ b/src/main/java/net/demilich/metastone/game/spells/CopyCardSpell.java
@@ -20,6 +20,7 @@ public class CopyCardSpell extends Spell {
 
 	@Override
 	protected void onCast(GameContext context, Player player, SpellDesc desc, Entity source, Entity target) {
+		int numberOfCardsToCopy = desc.getValue(SpellArg.VALUE, context, player, target, source, 1);
 		if (target != null) {
 			Card targetCard = null;
 			if (target.getEntityType() == EntityType.CARD) {
@@ -28,12 +29,13 @@ public class CopyCardSpell extends Spell {
 				Minion minion = (Minion) target;
 				targetCard = minion.getSourceCard();
 			}
-			context.getLogic().receiveCard(player.getId(), targetCard.getCopy());
+			for (int i = 0; i < numberOfCardsToCopy; i++) {
+				context.getLogic().receiveCard(player.getId(), targetCard.getCopy());
+			}
 			return;
 		}
 
 		CardLocation cardLocation = (CardLocation) desc.get(SpellArg.CARD_LOCATION);
-		int numberOfCardsToCopy = desc.getValue(SpellArg.VALUE, context, player, target, source, 1);
 
 		Player opponent = context.getOpponent(player);
 		CardCollection sourceCollection = null;

--- a/src/main/java/net/demilich/metastone/game/spells/MissilesSpell.java
+++ b/src/main/java/net/demilich/metastone/game/spells/MissilesSpell.java
@@ -19,7 +19,7 @@ public class MissilesSpell extends DamageSpell {
 	public void cast(GameContext context, Player player, SpellDesc desc, Entity source, List<Entity> targets) {
 		int missiles = desc.getValue(SpellArg.HOW_MANY, context, player, null, source, 2);
 
-		if (source.getEntityType() == EntityType.CARD && ((Card) source).getCardType() == CardType.SPELL) {
+		if (source.getEntityType() == EntityType.CARD && ((Card) source).getCardType().isCardType(CardType.SPELL)) {
 			missiles = context.getLogic().applySpellpower(player, source,  missiles);
 			missiles = context.getLogic().applyAmplify(player, missiles, Attribute.SPELL_AMPLIFY_MULTIPLIER);
 		}

--- a/src/main/java/net/demilich/metastone/game/spells/SummonRandomMinionFilteredSpell.java
+++ b/src/main/java/net/demilich/metastone/game/spells/SummonRandomMinionFilteredSpell.java
@@ -39,7 +39,9 @@ public class SummonRandomMinionFilteredSpell extends Spell {
 				
 		int boardPosition = SpellUtils.getBoardPosition(context, player, desc, source);
 		MinionCard minionCard = getRandomMatchingMinionCard(context, player, cardFilter, includeUncollectible);
-		context.getLogic().summon(player.getId(), minionCard.summon(), null, boardPosition, false);
+		if (minionCard != null) {
+			context.getLogic().summon(player.getId(), minionCard.summon(), null, boardPosition, false);
+		}
 	}
 
 }

--- a/src/main/java/net/demilich/metastone/game/spells/desc/filter/SpecificCardFilter.java
+++ b/src/main/java/net/demilich/metastone/game/spells/desc/filter/SpecificCardFilter.java
@@ -22,7 +22,7 @@ public class SpecificCardFilter extends EntityFilter {
 		}
 
 		String requiredCardId = desc.getString(FilterArg.CARD_ID);
-		return cardId.contains(requiredCardId);
+		return cardId.equalsIgnoreCase(requiredCardId);
 	}
 
 }

--- a/src/main/java/net/demilich/metastone/game/spells/trigger/SpellTrigger.java
+++ b/src/main/java/net/demilich/metastone/game/spells/trigger/SpellTrigger.java
@@ -114,7 +114,7 @@ public class SpellTrigger extends CustomCloneable implements IGameEventListener 
 		// longer matter.
 		// But let's check to make sure we don't accidentally expire something
 		// that's still using it.
-		if (oneTurn && event.getEventType() == GameEventType.TURN_END) {
+		if (oneTurn && (event.getEventType() == GameEventType.TURN_END || event.getEventType() == GameEventType.TURN_START)) {
 			expire();
 		}
 		try {

--- a/src/main/java/net/demilich/metastone/game/spells/trigger/TriggerManager.java
+++ b/src/main/java/net/demilich/metastone/game/spells/trigger/TriggerManager.java
@@ -52,7 +52,9 @@ public class TriggerManager implements Cloneable, IDisposable {
 			// In order to stop premature expiration, check
 			// for a oneTurnOnly tag and that it isn't delayed.
 			if (event.getEventType() == GameEventType.TURN_END) {
-				if (trigger.oneTurnOnly() && !trigger.isDelayed() && !trigger.interestedIn(event.getEventType())) {
+				if(trigger.oneTurnOnly() && !trigger.isDelayed() &&
+						!trigger.interestedIn(GameEventType.TURN_START) &&
+						!trigger.interestedIn(GameEventType.TURN_END)) {
 					trigger.expire();
 				}
 				trigger.delayTimeDown();

--- a/src/main/java/net/demilich/metastone/gui/playmode/HeroToken.java
+++ b/src/main/java/net/demilich/metastone/gui/playmode/HeroToken.java
@@ -84,8 +84,8 @@ public class HeroToken extends GameToken {
 		} else {
 			cardsLabel.setText("Fatigue: " + player.getHero().getAttributeValue(Attribute.FATIGUE));
 		}
-		if (player.getLockedMana() > 0) {
-			manaLabel.setText("Mana: " + player.getMana() + "/" + player.getMaxMana() + "\nOver: " + player.getLockedMana());
+		if (player.getHero().getAttributeValue(Attribute.OVERLOAD) > 0) {
+			manaLabel.setText("Mana: " + player.getMana() + "/" + player.getMaxMana() + "\nOver: " + player.getHero().getAttributeValue(Attribute.OVERLOAD));
 		} else {
 			manaLabel.setText("Mana: " + player.getMana() + "/" + player.getMaxMana());
 		}

--- a/src/main/java/net/demilich/metastone/gui/sandboxmode/MinionPanel.java
+++ b/src/main/java/net/demilich/metastone/gui/sandboxmode/MinionPanel.java
@@ -76,7 +76,7 @@ public class MinionPanel extends VBox {
 	private void populateMinions(String filter) {
 		ObservableList<MinionCard> data = FXCollections.observableArrayList();
 		for (Card card : CardCatalogue.getAll()) {
-			if (card.getCardType() != CardType.MINION) {
+			if (!card.getCardType().isCardType(CardType.MINION)) {
 				continue;
 			}
 			if (!card.matchesFilter(filter)) {


### PR DESCRIPTION
-Fixes OneTurn Triggers for TurnStartTrigger. This includes Conceal, Finicky Cloakfield, etc.
-Fixes SpecificCardFilter. Cards like minion_cthun and minion_cthuns_follower were being confused by the filter.
-Updated Spells
--Missiles Spells now checks for the Spell CardType, which fixes Choose One cards and Spell Damage.
--Fixed Summon Random Minion Filtered Spell to not try to summon null minions.
--Added Entity Filter to CardCostModifierSpell, and fixed its creation method.
-Fixed Ice Block to end at the end of the turn, instead of at the beginning of the next Turn. (Fixes Doomspeaker into Leper Gnome.)
-Fixed the start of the turn to come before the draw phase.
-Fixed Overload to display instead of the number of locked crystals.