### PR TITLE
create user directory if it does not exist on first startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-output
 report.log
 /~$card_checklist.xlsx
 build/
+classes/

--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
@@ -143,6 +143,11 @@ public class DeckProxy extends Proxy<GameNotification> {
 		FileOutputStream output = null;
 		String propertiesFilePath = BuildConfig.USER_HOME_METASTONE + File.separator + "metastone.properties";
 		try {
+            // create directories and property file if they do not exist
+            if (!Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().exists()){
+                Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().mkdirs();
+            }
+
 			File propertiesFile = new File(propertiesFilePath);
 			if (!propertiesFile.exists()) {
 				propertiesFile.createNewFile();

--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
@@ -57,6 +57,12 @@ public class DeckProxy extends Proxy<GameNotification> {
 
 	public DeckProxy() {
 		super(NAME);
+		// ensure user's personal deck dir exists
+		try {
+			Files.createDirectories(Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER));
+		} catch (IOException e) {
+			logger.error("Trouble creating", Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER));
+		}
 	}
 
 	public boolean addCardToDeck(Card card) {
@@ -143,11 +149,6 @@ public class DeckProxy extends Proxy<GameNotification> {
 		FileOutputStream output = null;
 		String propertiesFilePath = BuildConfig.USER_HOME_METASTONE + File.separator + "metastone.properties";
 		try {
-			// create directories and property file if they do not exist
-			if (!Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().exists()){
-				Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().mkdirs();
-			}
-
 			File propertiesFile = new File(propertiesFilePath);
 			if (!propertiesFile.exists()) {
 				propertiesFile.createNewFile();
@@ -308,9 +309,6 @@ public class DeckProxy extends Proxy<GameNotification> {
 
 		String jsonData = gson.toJson(saveData);
 		try {
-			// ensure user's personal deck dir exists
-			Files.createDirectories(Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER));
-
 			String filename = deck.getName().toLowerCase();
 			filename = filename.replaceAll(" ", "_");
 			filename = filename.replaceAll("\\W+", "");

--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
@@ -143,10 +143,10 @@ public class DeckProxy extends Proxy<GameNotification> {
 		FileOutputStream output = null;
 		String propertiesFilePath = BuildConfig.USER_HOME_METASTONE + File.separator + "metastone.properties";
 		try {
-            // create directories and property file if they do not exist
-            if (!Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().exists()){
-                Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().mkdirs();
-            }
+			// create directories and property file if they do not exist
+			if (!Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().exists()){
+				Paths.get(BuildConfig.USER_HOME_METASTONE).toFile().mkdirs();
+			}
 
 			File propertiesFile = new File(propertiesFilePath);
 			if (!propertiesFile.exists()) {


### PR DESCRIPTION
when running for first time and clicking play, this error occurs:
at java.io.WinNTFileSystem.createFileExclusively(Native Method)
at java.io.File.createNewFile(File.java:1012)
at

net.demilich.metastone.gui.deckbuilder.DeckProxy.copyDecksFromJar(DeckProxy.java:148)
at

net.demilich.metastone.gui.deckbuilder.DeckProxy.loadDecks(DeckProxy.java:128)
at

net.demilich.metastone.gui.deckbuilder.LoadDecksCommand.execute(LoadDecksCommand.java:18)
because the user directory does not exist. This fixes that.