### PR TITLE
Build config update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ report.log
 /~$card_checklist.xlsx
 build/
 classes/
+*.iml

--- a/README.md
+++ b/README.md
@@ -41,16 +41,22 @@ Sure! There is still a lot to do and anybody willing to contribute is welcome
 * Get a list of all gradle tasks: 
    * Linux/Mac OSX `./gradlew tasks --all`
    * Windows `gradlew.bat tasks --all`
-* If you want to build from Eclipse, you will need to create the Eclipse settings files: 
+
+#### Building with an IDE
+* If you want to build from Eclipse, create the Eclipse project files: 
    * Linux/Mac OSX `./gradlew eclipse`
    * Windows `gradlew.bat eclipse`
+   * _The above gradle task will automatically generate the `BuildConfig.java` file._
    * Open Eclipse and choose `File > Import > General > Existing projects into workspace`
    * Select the `Search for nested project` checkbox on the `Import Projects` screen.
-   * Change `Eclipse > Preferences > Java > Compiler > Compiler Complience Level` is set to 1.8
+   * Change `Eclipse > Preferences > Java > Compiler > Compiler Complience Level` to 1.8
    * Change `Eclipse > Preferences > Java > Compiler > Building > Circular dependencies` from `Error` to `Warning`.  There is a [known bug](https://issues.gradle.org/browse/GRADLE-2200) with importing multi-module gradle projects into Eclipse. The IDE of choice for working with gradle projects is [IntelliJ IDEA](https://www.jetbrains.com/idea/).
-* If you want to build from IntelliJ IDEA:
-   * Open a new project `File > Project From Existing Sources`.  Project will be imported from the `build.gradle` files.
-* **NOTE:** When building from an IDE you will need to manually generate the `BuildConfig.java` file, prefereably before you import the project.  Otherwise your IDE will complain about unresolved references to `BuildConfig`.
+* If you want to build from IntelliJ IDEA, create the IntelliJ project files:
+   * Linux/Mac OSX `./gradlew idea`
+   * Windows `gradlew.bat idea`
+   * _The above gradle task will automatically generate the `BuildConfig.java` file._
+   * Open IntelliJ and select `File > Open` then navigate to the project root dir.
+* ***Optionally*** (advanced option), you can choose to import the project into your respective IDE from the `build.gradle` files. When doing so, you **must** manually generate the `BuildConfig.java` file.  Otherwise your IDE will complain about unresolved references to `BuildConfig.java`.
    * Linux/Mac OSX `./gradlew compileBuildConfig`
    * Windows `gradlew.bat compileBuildConfig`
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ subprojects {
 
     apply plugin: 'java'
     apply plugin: 'eclipse'
+    apply plugin: 'idea'
+
     sourceCompatibility = 1.8
 
     project.version = '1.1.0'

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -22,8 +22,12 @@ buildConfig {
 	buildConfigField 'String', 'USER_HOME_METASTONE', (FileSystemView.getFileSystemView().getDefaultDirectory().getPath() + File.separator + rootProject.name).replace("\\", "\\\\")
 }
 
+ext {
+	buildConfigSrcDir = file("$buildDir/gen/buildconfig/src/main")
+}
+
 sourceSets.main.java {
-	srcDir 'build/gen/buildconfig/src/main'
+	srcDir buildConfigSrcDir
 }
 
 dependencies {
@@ -35,3 +39,6 @@ task compileBuildConfigFirst (dependsOn: ['compileBuildConfig'])
 eclipseProject.dependsOn(compileBuildConfigFirst)
 ideaModule.dependsOn(compileBuildConfigFirst)
 
+idea.module {
+	generatedSourceDirs += file(buildConfigSrcDir)
+}

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 		}
 	}
 	dependencies {
-		classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.2'
+		classpath 'gradle.plugin.de.fuerstenau:BuildConfigPlugin:1.1.4'
 	}
 }
 
@@ -30,3 +30,8 @@ dependencies {
 	compile files('lib/nitty-gritty-mvc.jar')
 	compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3'
 }
+
+task compileBuildConfigFirst (dependsOn: ['compileBuildConfig'])
+eclipseProject.dependsOn(compileBuildConfigFirst)
+ideaModule.dependsOn(compileBuildConfigFirst)
+


### PR DESCRIPTION
Simplified the `BuildConfig.java` file generation.  It will now be automatically created when you create your Eclipse or IntelliJ project files using the gradle task for your respective IDE.