### PR TITLE
Fixed Yogg-Saron and Mimiron's Head

### DIFF
--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_mimirons_head.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_mimirons_head.json
@@ -31,6 +31,9 @@
 					}
 				},
 				{
+					"class": "ForceDeathPhaseSpell"
+				},
+				{
 					"class": "SummonSpell",
 					"card": "token_v-07-tr-0n"
 				}

--- a/game/src/main/java/net/demilich/metastone/game/cards/ChooseOneCard.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/ChooseOneCard.java
@@ -38,6 +38,10 @@ public class ChooseOneCard extends Card implements IChooseOneCard {
 		}
 		return cards;
 	}
+	
+	public Card getBothChoicesCard() {
+		return getCard(cardId);
+	}
 
 	@Override
 	public PlayCardAction play() {

--- a/game/src/main/java/net/demilich/metastone/game/spells/ForceDeathPhaseSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/ForceDeathPhaseSpell.java
@@ -1,0 +1,22 @@
+package net.demilich.metastone.game.spells;
+
+import java.util.Map;
+import net.demilich.metastone.game.GameContext;
+import net.demilich.metastone.game.Player;
+import net.demilich.metastone.game.entities.Entity;
+import net.demilich.metastone.game.spells.desc.SpellArg;
+import net.demilich.metastone.game.spells.desc.SpellDesc;
+
+public class ForceDeathPhaseSpell extends Spell {
+
+	public static SpellDesc create() {
+		Map<SpellArg, Object> arguments = SpellDesc.build(ForceDeathPhaseSpell.class);
+		return new SpellDesc(arguments);
+	}
+
+	@Override
+	protected void onCast(GameContext context, Player player, SpellDesc desc, Entity source, Entity target) {
+		context.getLogic().checkForDeadEntities();
+	}
+
+}


### PR DESCRIPTION
- Yogg-Saron now more accurately emulates implementation.
 - Yogg-Saron checks for death's after each spell.
 - Yogg-Saron casts spells only for the owner, instead of the original owner.
 - Yogg-Saron casts the doubled version of Choose One cards if you have Fandral in play.
- Mimiron's Head now forces a death phase before summoning V-0L-TR0N.