### PR TITLE
Fixed C'Thun cards

### DIFF
--- a/cards/src/main/resources/cards/the_old_gods/druid/minion_klaxxi_amber-weaver.json
+++ b/cards/src/main/resources/cards/the_old_gods/druid/minion_klaxxi_amber-weaver.json
@@ -46,23 +46,14 @@
 					"value2": 10
 				},
 				{
-					"class": "AndCondition",
-					"conditions": [
-						{
-							"class": "DeckContainsCondition",
-							"cardId": "minion_cthun"
-						},
-						{
-							"class": "ComparisonCondition",
-							"operation": "GREATER_OR_EQUAL",
-							"value1": {
-								"class": "AttributeValueProvider",
-								"target": "FRIENDLY_HERO",
-								"attribute": "CTHUN_ATTACK_BUFF"
-							},
-							"value2": 4
-						}
-					]
+					"class": "ComparisonCondition",
+					"operation": "GREATER_OR_EQUAL",
+					"value1": {
+						"class": "AttributeValueProvider",
+						"target": "FRIENDLY_HERO",
+						"attribute": "CTHUN_ATTACK_BUFF"
+					},
+					"value2": 4
 				}
 			]
 		}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_twin_emperor_veklor.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_twin_emperor_veklor.json
@@ -45,23 +45,14 @@
 					"value2": 10
 				},
 				{
-					"class": "AndCondition",
-					"conditions": [
-						{
-							"class": "DeckContainsCondition",
-							"cardId": "minion_cthun"
-						},
-						{
-							"class": "ComparisonCondition",
-							"operation": "GREATER_OR_EQUAL",
-							"value1": {
-								"class": "AttributeValueProvider",
-								"target": "FRIENDLY_HERO",
-								"attribute": "CTHUN_ATTACK_BUFF"
-							},
-							"value2": 4
-						}
-					]
+					"class": "ComparisonCondition",
+					"operation": "GREATER_OR_EQUAL",
+					"value1": {
+						"class": "AttributeValueProvider",
+						"target": "FRIENDLY_HERO",
+						"attribute": "CTHUN_ATTACK_BUFF"
+					},
+					"value2": 4
 				}
 			]
 		}

--- a/cards/src/main/resources/cards/the_old_gods/priest/minion_twilight_darkmender.json
+++ b/cards/src/main/resources/cards/the_old_gods/priest/minion_twilight_darkmender.json
@@ -46,23 +46,14 @@
 					"value2": 10
 				},
 				{
-					"class": "AndCondition",
-					"conditions": [
-						{
-							"class": "DeckContainsCondition",
-							"cardId": "minion_cthun"
-						},
-						{
-							"class": "ComparisonCondition",
-							"operation": "GREATER_OR_EQUAL",
-							"value1": {
-								"class": "AttributeValueProvider",
-								"target": "FRIENDLY_HERO",
-								"attribute": "CTHUN_ATTACK_BUFF"
-							},
-							"value2": 4
-						}
-					]
+					"class": "ComparisonCondition",
+					"operation": "GREATER_OR_EQUAL",
+					"value1": {
+						"class": "AttributeValueProvider",
+						"target": "FRIENDLY_HERO",
+						"attribute": "CTHUN_ATTACK_BUFF"
+					},
+					"value2": 4
 				}
 			]
 		}

--- a/cards/src/main/resources/cards/the_old_gods/warrior/minion_ancient_shieldbearer.json
+++ b/cards/src/main/resources/cards/the_old_gods/warrior/minion_ancient_shieldbearer.json
@@ -46,23 +46,14 @@
 					"value2": 10
 				},
 				{
-					"class": "AndCondition",
-					"conditions": [
-						{
-							"class": "DeckContainsCondition",
-							"cardId": "minion_cthun"
-						},
-						{
-							"class": "ComparisonCondition",
-							"operation": "GREATER_OR_EQUAL",
-							"value1": {
-								"class": "AttributeValueProvider",
-								"target": "FRIENDLY_HERO",
-								"attribute": "CTHUN_ATTACK_BUFF"
-							},
-							"value2": 4
-						}
-					]
+					"class": "ComparisonCondition",
+					"operation": "GREATER_OR_EQUAL",
+					"value1": {
+						"class": "AttributeValueProvider",
+						"target": "FRIENDLY_HERO",
+						"attribute": "CTHUN_ATTACK_BUFF"
+					},
+					"value2": 4
 				}
 			]
 		}


### PR DESCRIPTION
- C'Thun cards do not require C'Thun to be in the deck to proc.