### PR TITLE
Make the User's Home Metastone folder a runtime configurable value

### DIFF
--- a/app/src/main/java/net/demilich/metastone/MetaStone.java
+++ b/app/src/main/java/net/demilich/metastone/MetaStone.java
@@ -8,11 +8,19 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import net.demilich.metastone.gui.IconFactory;
+import net.demilich.metastone.utils.UserHomeMetastone;
+
+import javax.swing.filechooser.FileSystemView;
+import java.io.File;
 
 public class MetaStone extends Application {
 
 	public static void main(String[] args) {
 		//DevCardTools.formatJsons();
+
+		// initialize the user home metastone dir path with the platform specific path for the user starting up the app
+		UserHomeMetastone.init((FileSystemView.getFileSystemView().getDefaultDirectory().getPath()
+				+ File.separator + BuildConfig.NAME).replace("\\", "\\\\"));
 		launch(args);
 	}
 

--- a/app/src/main/java/net/demilich/metastone/gui/cards/CardProxy.java
+++ b/app/src/main/java/net/demilich/metastone/gui/cards/CardProxy.java
@@ -1,13 +1,11 @@
 package net.demilich.metastone.gui.cards;
 
-import net.demilich.metastone.BuildConfig;
 import net.demilich.metastone.GameNotification;
 import net.demilich.metastone.game.cards.CardCatalogue;
 import net.demilich.nittygrittymvc.Proxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -22,14 +20,14 @@ public class CardProxy extends Proxy<GameNotification> {
 		super(NAME);
 		try {
 			// ensure user's personal cards dir exists
-			Files.createDirectories(Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + CardCatalogue.CARDS_FOLDER));
+			Files.createDirectories(Paths.get(CardCatalogue.CARDS_FOLDER_PATH));
 			// ensure cards have been copied to ~/metastone/cards
 			CardCatalogue.copyCardsFromJar();
 			CardCatalogue.loadCards();
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
 		} catch (IOException e) {
-			logger.error("Trouble creating " +  Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + CardCatalogue.CARDS_FOLDER));
+			logger.error("Trouble creating " +  Paths.get(CardCatalogue.CARDS_FOLDER_PATH));
 			e.printStackTrace();
 		}
 	}

--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckProxy.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 import net.demilich.metastone.BuildConfig;
 import net.demilich.metastone.utils.ResourceInputStream;
 import net.demilich.metastone.utils.ResourceLoader;
+import net.demilich.metastone.utils.UserHomeMetastone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,7 @@ public class DeckProxy extends Proxy<GameNotification> {
 
 	public static final String NAME = "DeckProxy";
 	private static final String DECKS_FOLDER = "decks";
+	private static final String DECKS_FOLDER_PATH = UserHomeMetastone.getPath() + File.separator + DECKS_FOLDER;
 	private static final String DECKS_COPIED_PROPERTY = "decks.copied";
 
 	private final List<Deck> decks = new ArrayList<Deck>();
@@ -59,11 +61,11 @@ public class DeckProxy extends Proxy<GameNotification> {
 		super(NAME);
 		try {
 			// ensure user's personal deck dir exists
-			Files.createDirectories(Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER));
+			Files.createDirectories(Paths.get(DECKS_FOLDER_PATH));
 			// ensure decks have been copied to ~/metastone/decks
 			copyDecksFromJar();
 		} catch (IOException e) {
-			logger.error("Trouble creating " + Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER));
+			logger.error("Trouble creating " + Paths.get(DECKS_FOLDER_PATH));
 			e.printStackTrace();
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
@@ -116,7 +118,7 @@ public class DeckProxy extends Proxy<GameNotification> {
 	public void deleteDeck(Deck deck) {
 		decks.remove(deck);
 		logger.debug("Trying to delete deck '{}' contained in file '{}'...", deck.getName(), deck.getFilename());
-		Path path = Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER + File.separator + deck.getFilename());
+		Path path = Paths.get(DECKS_FOLDER_PATH + File.separator + deck.getFilename());
 		try {
 		    Files.delete(path);
 		} catch (NoSuchFileException x) {
@@ -136,10 +138,10 @@ public class DeckProxy extends Proxy<GameNotification> {
 		decks.clear();
 
 		// load decks from ~/metastone/decks on the filesystem
-		loadStandardDecks(ResourceLoader.loadJsonInputStreams(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER, true),
+		loadStandardDecks(ResourceLoader.loadJsonInputStreams(DECKS_FOLDER_PATH, true),
 				new GsonBuilder().setPrettyPrinting().create());
 
-		loadMetaDecks(ResourceLoader.loadJsonInputStreams(BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER, true),
+		loadMetaDecks(ResourceLoader.loadJsonInputStreams(DECKS_FOLDER_PATH, true),
 				new GsonBuilder().setPrettyPrinting().create());
 	}
 
@@ -147,7 +149,7 @@ public class DeckProxy extends Proxy<GameNotification> {
 		Properties prop = new Properties();
 		InputStream input = null;
 		FileOutputStream output = null;
-		String propertiesFilePath = BuildConfig.USER_HOME_METASTONE + File.separator + "metastone.properties";
+		String propertiesFilePath = UserHomeMetastone.getPath() + File.separator + "metastone.properties";
 		try {
 			File propertiesFile = new File(propertiesFilePath);
 			if (!propertiesFile.exists()) {
@@ -160,7 +162,7 @@ public class DeckProxy extends Proxy<GameNotification> {
 
 			// if we have not copied decks to the USER_HOME_METASTONE decks folder, then do so now
 			if (!Boolean.parseBoolean(prop.getProperty(DECKS_COPIED_PROPERTY))) {
-				ResourceLoader.copyFromResources(DECKS_FOLDER, BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER);
+				ResourceLoader.copyFromResources(DECKS_FOLDER, DECKS_FOLDER_PATH);
 
 				output = new FileOutputStream(propertiesFile);
 				// set a property to indicate that we have copied decks
@@ -312,7 +314,7 @@ public class DeckProxy extends Proxy<GameNotification> {
 			String filename = deck.getName().toLowerCase();
 			filename = filename.replaceAll(" ", "_");
 			filename = filename.replaceAll("\\W+", "");
-			filename = BuildConfig.USER_HOME_METASTONE + File.separator + DECKS_FOLDER + File.separator + filename + ".json";
+			filename = DECKS_FOLDER_PATH + File.separator + filename + ".json";
 			Path path = Paths.get(filename);
 			Files.write(path, jsonData.getBytes());
 			deck.setFilename(path.getFileName().toString());

--- a/app/src/main/java/net/demilich/metastone/gui/trainingmode/TrainingProxy.java
+++ b/app/src/main/java/net/demilich/metastone/gui/trainingmode/TrainingProxy.java
@@ -15,6 +15,7 @@ import net.demilich.metastone.BuildConfig;
 import net.demilich.metastone.trainingmode.TrainingData;
 import net.demilich.metastone.utils.ResourceInputStream;
 import net.demilich.metastone.utils.ResourceLoader;
+import net.demilich.metastone.utils.UserHomeMetastone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,7 @@ public class TrainingProxy extends Proxy<GameNotification> {
 
 	public static final String NAME = "TrainingProxy";
 	private static final String TRAINING_FOLDER = "training";
+	private static final String TRAINING_FOLDER_PATH = UserHomeMetastone.getPath() + File.separator + TRAINING_FOLDER;
 
 	private static Logger logger = LoggerFactory.getLogger(TrainingProxy.class);
 
@@ -38,8 +40,8 @@ public class TrainingProxy extends Proxy<GameNotification> {
 
 	public TrainingProxy() {
 		super(NAME);
-		if (new File(BuildConfig.USER_HOME_METASTONE + File.separator + TRAINING_FOLDER).mkdir()) {
-			logger.info(BuildConfig.USER_HOME_METASTONE + File.separator + TRAINING_FOLDER + " folder created");
+		if (new File(TRAINING_FOLDER_PATH).mkdir()) {
+			logger.info(TRAINING_FOLDER_PATH + " folder created");
 		}
 		try {
 			loadTrainingData();
@@ -63,8 +65,8 @@ public class TrainingProxy extends Proxy<GameNotification> {
 		Collection<ResourceInputStream> inputStreams = ResourceLoader.loadJsonInputStreams(TRAINING_FOLDER, false);
 
 		// load cards from ~/metastone/training folder on the filesystem
-		if (Paths.get(BuildConfig.USER_HOME_METASTONE + File.separator + TRAINING_FOLDER).toFile().exists()) {
-			inputStreams.addAll((ResourceLoader.loadJsonInputStreams(BuildConfig.USER_HOME_METASTONE + File.separator + TRAINING_FOLDER, true)));
+		if (Paths.get(TRAINING_FOLDER_PATH).toFile().exists()) {
+			inputStreams.addAll((ResourceLoader.loadJsonInputStreams(TRAINING_FOLDER_PATH, true)));
 		}
 
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -115,7 +117,7 @@ public class TrainingProxy extends Proxy<GameNotification> {
 			String filename = deckName.toLowerCase();
 			filename = filename.replaceAll(" ", "_");
 			filename = filename.replaceAll("\\W+", "");
-			filename = BuildConfig.USER_HOME_METASTONE + File.separator + TRAINING_FOLDER + File.separator + filename + ".json";
+			filename = TRAINING_FOLDER_PATH + File.separator + filename + ".json";
 			Files.write(Paths.get(filename), jsonData.getBytes());
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/cards/src/test/java/net/demilich/metastone/tests/ValidateCards.java
+++ b/cards/src/test/java/net/demilich/metastone/tests/ValidateCards.java
@@ -3,6 +3,7 @@ package net.demilich.metastone.tests;
 import net.demilich.metastone.BuildConfig;
 import net.demilich.metastone.game.cards.CardParser;
 import net.demilich.metastone.utils.ResourceInputStream;
+import net.demilich.metastone.utils.UserHomeMetastone;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
@@ -10,6 +11,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import javax.swing.filechooser.FileSystemView;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -28,16 +30,20 @@ public class ValidateCards {
     private static final List<File> ALL_CARD_FILES;
 
     static {
+        // initialize the user home metastone dir path with the platform specific path for the user starting up the app
+        UserHomeMetastone.init((FileSystemView.getFileSystemView().getDefaultDirectory().getPath()
+                + File.separator + BuildConfig.NAME).replace("\\", "\\\\"));
+
         // recursively crawl the cards dir and pull out all the files
         ALL_CARD_FILES = (List<File>)FileUtils.listFiles(
                 new File(CARDS_DIR),
                 new RegexFileFilter("^(.*json)"),
                 DirectoryFileFilter.DIRECTORY);
         // also pull in the user's custom cards dir
-        if (new File(BuildConfig.USER_HOME_METASTONE + File.separator + "cards").exists()) {
+        if (new File(UserHomeMetastone.getPath() + File.separator + "cards").exists()) {
             ALL_CARD_FILES.addAll(
                     FileUtils.listFiles(
-                        new File(BuildConfig.USER_HOME_METASTONE + File.separator + "cards"),
+                        new File(UserHomeMetastone.getPath() + File.separator + "cards"),
                         new RegexFileFilter("^(.*json)"),
                         DirectoryFileFilter.DIRECTORY)
             );

--- a/game/src/main/java/net/demilich/metastone/game/cards/CardCatalogue.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/CardCatalogue.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.demilich.metastone.BuildConfig;
+import net.demilich.metastone.utils.UserHomeMetastone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +29,7 @@ public class CardCatalogue {
 
 	private final static CardCollection cards = new CardCollection();
 	public static final String CARDS_FOLDER = "cards";
+	public static final String CARDS_FOLDER_PATH = UserHomeMetastone.getPath() + File.separator + CARDS_FOLDER;
 	private static final String CARDS_COPIED_PROPERTY = "cards.copied";
 	private static Logger logger = LoggerFactory.getLogger(CardCatalogue.class);
 
@@ -131,7 +133,7 @@ public class CardCatalogue {
 	public static void loadCards() throws IOException, URISyntaxException {
 
 		// load cards from ~/metastone/cards on the file system
-		Collection<ResourceInputStream> inputStreams = ResourceLoader.loadJsonInputStreams(BuildConfig.USER_HOME_METASTONE + File.separator + CARDS_FOLDER, true);
+		Collection<ResourceInputStream> inputStreams = ResourceLoader.loadJsonInputStreams(CARDS_FOLDER_PATH, true);
 
 		Map<String, CardDesc> cardDesc = new HashMap<String, CardDesc>();
 		CardParser cardParser = new CardParser();
@@ -159,7 +161,7 @@ public class CardCatalogue {
 		Properties prop = new Properties();
 		InputStream input = null;
 		FileOutputStream output = null;
-		String propertiesFilePath = BuildConfig.USER_HOME_METASTONE + File.separator + "metastone.properties";
+		String propertiesFilePath = UserHomeMetastone.getPath() + File.separator + "metastone.properties";
 		try {
 			File propertiesFile = new File(propertiesFilePath);
 			if (!propertiesFile.exists()) {
@@ -172,7 +174,7 @@ public class CardCatalogue {
 
 			// if we have not copied cards to the USER_HOME_METASTONE cards folder, then do so now
 			if (!Boolean.parseBoolean(prop.getProperty(CARDS_COPIED_PROPERTY))) {
-				ResourceLoader.copyFromResources(CARDS_FOLDER, BuildConfig.USER_HOME_METASTONE + File.separator + CARDS_FOLDER);
+				ResourceLoader.copyFromResources(CARDS_FOLDER, CARDS_FOLDER_PATH);
 
 				output = new FileOutputStream(propertiesFile);
 				// set a property to indicate that we have copied the cards

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -10,16 +10,14 @@ buildscript {
 }
 
 apply plugin: 'de.fuerstenau.buildconfig'
-import javax.swing.filechooser.FileSystemView;
 
-// will generate an BuildConfig.java file in 'build/gen/buildconfig/src/main'
+// will generate a BuildConfig.java file in 'build/gen/buildconfig/src/main'
 buildConfig {
 	packageName = 'net.demilich.metastone'
 	version = project.version
 	appName = rootProject.name
 	buildConfigField 'boolean', 'DEV_BUILD', project.hasProperty('DEV_BUILD').toString()
 	buildConfigField 'int', 'DEFAULT_SLEEP_DELAY', '100'
-	buildConfigField 'String', 'USER_HOME_METASTONE', (FileSystemView.getFileSystemView().getDefaultDirectory().getPath() + File.separator + rootProject.name).replace("\\", "\\\\")
 }
 
 ext {

--- a/shared/src/main/java/net/demilich/metastone/utils/UserHomeMetastone.java
+++ b/shared/src/main/java/net/demilich/metastone/utils/UserHomeMetastone.java
@@ -1,0 +1,34 @@
+package net.demilich.metastone.utils;
+
+/**
+ * Singleton data class that holds the platform specific path to the metastone user home dir.
+ */
+public class UserHomeMetastone {
+
+    private static UserHomeMetastone INSTANCE;
+    private String dirPath;
+
+    private UserHomeMetastone(String path) {
+        dirPath = path;
+    }
+
+    public static void init(String path) {
+        if(path == null) {
+            throw new NullPointerException("UserHomeMetastone.init(path) cannot be initialized with null!");
+        }
+
+        if (INSTANCE == null) {
+            INSTANCE = new UserHomeMetastone(path);
+        } else {
+            INSTANCE.dirPath = path;
+        }
+    }
+
+    public static String getPath() {
+        if (INSTANCE == null) {
+            throw new RuntimeException("UserHomeMetastone must first be initialized!");
+        }
+
+        return INSTANCE.dirPath;
+    }
+}


### PR DESCRIPTION
- added a UserHomeMetastone singleton data class in the shared module's util package
- updated the MetaStone.java application class to initialize the UserHomeMetastone data class.
- updated all usage of USER_HOME_METASTONE and replaced it with references to UserHomeMetastone.getPath()
- removed USER_HOME_METASTONE from the buildConfig closure in shared/build.gradle

Fix for #175