### PR TITLE
NullPointerException fix missing cards in deck

### DIFF
--- a/game/src/main/java/net/demilich/metastone/game/decks/DeckFormat.java
+++ b/game/src/main/java/net/demilich/metastone/game/decks/DeckFormat.java
@@ -22,6 +22,11 @@ public class DeckFormat {
 
 	public boolean inSet(Deck deck) {
 		for (Card card : deck.getCards()) {
+			if(card == null) {
+				// TODO may want to print a warning message here, or somewhere else, that a deck probably contains a misspelled card?
+				return false;
+			}
+			
 			if (!sets.contains(card.getCardSet())) {
 				return false;
 			}


### PR DESCRIPTION
fixed a NullPointerException caused by decks containing null-cards (which can happen, for example, due to misspelling the name of a card in a deck)

The bug is described in Issue #202 

I fixed it in the simplest way I could think of. It may be desirable to fix it in a different way instead (for instance, making sure that null-cards never get added to decks to begin with), but that's up to you.

NOTE: as described in Issue #202 there are actually two problems. The first is that when a deck contains a null as card, it causes a crash when retrieving the list of decks for the drop-down menu where you can select a deck to play. This is what I fixed. The second problem is that the MalyDragonLock deck actually has an incorrect definition, because the Alexstrasza card is incorrectly named. I didn't fix this yet in case you first want to test the NullPointerException fix that I implemented, but it's probably a good idea to also actually fix the deck afterwards.