### PR TITLE
Fixed Battlecry Resolution and Jaraxxus

### DIFF
--- a/cards/src/main/resources/cards/basic/hunter/minion_houndmaster.json
+++ b/cards/src/main/resources/cards/basic/hunter/minion_houndmaster.json
@@ -27,8 +27,7 @@
 				"class": "RaceFilter",
 				"race": "BEAST"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_darkscale_healer.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_darkscale_healer.json
@@ -14,8 +14,7 @@
 			"class": "HealSpell",
 			"target": "FRIENDLY_CHARACTERS",
 			"value": 2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_dragonling_mechanic.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_dragonling_mechanic.json
@@ -13,8 +13,7 @@
 			"class": "SummonSpell",
 			"card": "token_mechanical_dragonling",
 			"boardPositionRelative": "RIGHT"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_elven_archer.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_elven_archer.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "DamageSpell",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_frostwolf_warlord.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_frostwolf_warlord.json
@@ -17,8 +17,7 @@
 				"class": "EntityCounter",
 				"target": "OTHER_FRIENDLY_MINIONS"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_gnomish_inventor.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_gnomish_inventor.json
@@ -12,8 +12,7 @@
 		"spell": {
 			"class": "DrawCardSpell",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_ironforge_rifleman.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_ironforge_rifleman.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "DamageSpell",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_murloc_tidehunter.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_murloc_tidehunter.json
@@ -14,8 +14,7 @@
 			"class": "SummonSpell",
 			"card": "token_murloc_scout",
 			"boardPositionRelative": "RIGHT"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_nightblade.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_nightblade.json
@@ -13,8 +13,7 @@
 			"class": "DamageSpell",
 			"target": "ENEMY_HERO",
 			"value": 3
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_novice_engineer.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_novice_engineer.json
@@ -11,8 +11,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "DrawCardSpell"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_razorfen_hunter.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_razorfen_hunter.json
@@ -13,8 +13,7 @@
 			"class": "SummonSpell",
 			"card": "token_boar",
 			"boardPositionRelative": "RIGHT"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_shattered_sun_cleric.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_shattered_sun_cleric.json
@@ -14,8 +14,7 @@
 			"class": "BuffSpell",
 			"attackBonus": 1,
 			"hpBonus": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_stormpike_commando.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_stormpike_commando.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "DamageSpell",
 			"value": 2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/neutral/minion_voodoo_doctor.json
+++ b/cards/src/main/resources/cards/basic/neutral/minion_voodoo_doctor.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "HealSpell",
 			"value": 2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/paladin/minion_guardian_of_kings.json
+++ b/cards/src/main/resources/cards/basic/paladin/minion_guardian_of_kings.json
@@ -13,8 +13,7 @@
 			"class": "HealSpell",
 			"target": "FRIENDLY_HERO",
 			"value": 6
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/shaman/minion_fire_elemental.json
+++ b/cards/src/main/resources/cards/basic/shaman/minion_fire_elemental.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "DamageSpell",
 			"value": 3
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/shaman/minion_windspeaker.json
+++ b/cards/src/main/resources/cards/basic/shaman/minion_windspeaker.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "AddAttributeSpell",
 			"attribute": "WINDFURY"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/warlock/minion_dread_infernal.json
+++ b/cards/src/main/resources/cards/basic/warlock/minion_dread_infernal.json
@@ -14,8 +14,7 @@
 			"class": "DamageSpell",
 			"target": "ALL_OTHER_CHARACTERS",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/basic/warlock/minion_succubus.json
+++ b/cards/src/main/resources/cards/basic/warlock/minion_succubus.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "DiscardSpell",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_blackwing_corruptor.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_blackwing_corruptor.json
@@ -17,8 +17,7 @@
 		"condition": {
 			"class": "HoldsCardCondition",
 			"race": "DRAGON"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_blackwing_technician.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_blackwing_technician.json
@@ -19,8 +19,7 @@
 		"condition": {
 			"class": "HoldsCardCondition",
 			"race": "DRAGON"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_core_rager.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_core_rager.json
@@ -20,8 +20,7 @@
 			"class": "CardCountCondition",
 			"operation": "LESS_OR_EQUAL",
 			"value": 0
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_dark_iron_skulker.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_dark_iron_skulker.json
@@ -17,8 +17,7 @@
 				"class": "DamagedFilter",
 				"invert": true
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_dragon_consort.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_dragon_consort.json
@@ -25,8 +25,7 @@
 					"race": "DRAGON"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_drakonid_crusher.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_drakonid_crusher.json
@@ -22,8 +22,7 @@
 			"attribute": "HP",
 			"operation": "LESS_OR_EQUAL",
 			"value": 15
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_fireguard_destroyer.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_fireguard_destroyer.json
@@ -17,8 +17,7 @@
 				"min": 1,
 				"max": 4
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_hungry_dragon.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_hungry_dragon.json
@@ -18,8 +18,7 @@
 				"cardType": "MINION",
 				"manaCost": 1
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_nefarian.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_nefarian.json
@@ -19,8 +19,7 @@
 				"cardType": "SPELL",
 				"heroClass": "OPPONENT"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_rend_blackhand.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_rend_blackhand.json
@@ -20,8 +20,7 @@
 		"condition": {
 			"class": "HoldsCardCondition",
 			"race": "DRAGON"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_twilight_whelp.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_twilight_whelp.json
@@ -18,8 +18,7 @@
 		"condition": {
 			"class": "HoldsCardCondition",
 			"race": "DRAGON"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/mage/minion_kirin_tor_mage.json
+++ b/cards/src/main/resources/cards/classic/mage/minion_kirin_tor_mage.json
@@ -22,8 +22,7 @@
 				},
 				"requiredAttribute": "SECRET"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_ancient_mage.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_ancient_mage.json
@@ -15,8 +15,7 @@
 			"target": "ADJACENT_MINIONS",
 			"attribute": "SPELL_DAMAGE",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_azure_drake.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_azure_drake.json
@@ -14,8 +14,7 @@
 		"spell": {
 			"class": "DrawCardSpell",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/classic/neutral/minion_big_game_hunter.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_big_game_hunter.json
@@ -18,8 +18,7 @@
 				"operation": "GREATER",
 				"value": 6
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_blood_knight.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_blood_knight.json
@@ -29,8 +29,7 @@
 					"attribute": "DIVINE_SHIELD"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_bloodsail_corsair.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_bloodsail_corsair.json
@@ -14,8 +14,7 @@
 			"class": "ModifyDurabilitySpell",
 			"targetPlayer": "OPPONENT",
 			"value": -1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_bloodsail_raider.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_bloodsail_raider.json
@@ -18,8 +18,7 @@
 				"target": "FRIENDLY_WEAPON",
 				"attribute": "ATTACK"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_captain_greenskin.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_captain_greenskin.json
@@ -15,8 +15,7 @@
 			"target": "FRIENDLY_WEAPON",
 			"attackBonus": 1,
 			"hpBonus": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_coldlight_oracle.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_coldlight_oracle.json
@@ -14,8 +14,7 @@
 			"class": "DrawCardSpell",
 			"targetPlayer": "BOTH",
 			"value": 2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_coldlight_seer.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_coldlight_seer.json
@@ -18,8 +18,7 @@
 				"class": "RaceFilter",
 				"race": "MURLOC"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_crazed_alchemist.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_crazed_alchemist.json
@@ -12,8 +12,7 @@
 		"targetSelection": "MINIONS",
 		"spell": {
 			"class": "SwapAttackAndHpSpell"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_dark_iron_dwarf.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_dark_iron_dwarf.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "TemporaryAttackSpell",
 			"value": 2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_deathwing.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_deathwing.json
@@ -23,8 +23,7 @@
 					"value": -1
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_defender_of_argus.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_defender_of_argus.json
@@ -23,8 +23,7 @@
 					"attribute": "TAUNT"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_faceless_manipulator.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_faceless_manipulator.json
@@ -12,8 +12,7 @@
 		"targetSelection": "MINIONS",
 		"spell": {
 			"class": "custom.FacelessSpell"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_frost_elemental.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_frost_elemental.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "AddAttributeSpell",
 			"attribute": "FROZEN"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_harrison_jones.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_harrison_jones.json
@@ -25,8 +25,7 @@
 					"target": "ENEMY_WEAPON"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_hungry_crab.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_hungry_crab.json
@@ -28,8 +28,7 @@
 				"class": "RaceFilter",
 				"race": "MURLOC"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_injured_blademaster.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_injured_blademaster.json
@@ -13,8 +13,7 @@
 			"class": "DamageSpell",
 			"target": "SELF",
 			"value": 4
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_ironbeak_owl.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_ironbeak_owl.json
@@ -13,8 +13,7 @@
 		"targetSelection": "MINIONS",
 		"spell": {
 			"class": "SilenceSpell"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_king_mukla.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_king_mukla.json
@@ -17,8 +17,7 @@
 				"spell_bananas",
 				"spell_bananas"
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_leeroy_jenkins.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_leeroy_jenkins.json
@@ -17,8 +17,7 @@
 				"token_whelp",
 				"token_whelp"
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/classic/neutral/minion_mad_bomber.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_mad_bomber.json
@@ -15,8 +15,7 @@
 			"value": 1,
 			"howMany": 3,
 			"randomTarget": true
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_millhouse_manastorm.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_millhouse_manastorm.json
@@ -23,8 +23,7 @@
 					"targetPlayer": "OPPONENT"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_mind_control_tech.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_mind_control_tech.json
@@ -19,8 +19,7 @@
 			"targetPlayer": "OPPONENT",
 			"operation": "GREATER_OR_EQUAL",
 			"value": 4
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_onyxia.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_onyxia.json
@@ -44,8 +44,7 @@
 					"boardPositionRelative": "LEFT"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_priestess_of_elune.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_priestess_of_elune.json
@@ -13,8 +13,7 @@
 			"class": "HealSpell",
 			"target": "FRIENDLY_HERO",
 			"value": 4
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_silver_hand_knight.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_silver_hand_knight.json
@@ -13,8 +13,7 @@
 			"class": "SummonSpell",
 			"card": "token_squire",
 			"boardPositionRelative": "RIGHT"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_spellbreaker.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_spellbreaker.json
@@ -12,8 +12,7 @@
 		"targetSelection": "MINIONS",
 		"spell": {
 			"class": "SilenceSpell"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_stampeding_kodo.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_stampeding_kodo.json
@@ -21,8 +21,7 @@
 				"operation": "LESS_OR_EQUAL",
 				"value": 2
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_sunfury_protector.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_sunfury_protector.json
@@ -13,8 +13,7 @@
 			"class": "AddAttributeSpell",
 			"target": "ADJACENT_MINIONS",
 			"attribute": "TAUNT"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_the_black_knight.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_the_black_knight.json
@@ -17,8 +17,7 @@
 				"attribute": "TAUNT",
 				"operation": "HAS"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_tinkmaster_overspark.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_tinkmaster_overspark.json
@@ -26,8 +26,7 @@
 			"condition": {
 				"class": "RandomCondition"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/neutral/minion_twilight_drake.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_twilight_drake.json
@@ -18,8 +18,7 @@
 				"targetPlayer": "SELF",
 				"playerAttribute": "HAND_COUNT"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/paladin/minion_aldor_peacekeeper.json
+++ b/cards/src/main/resources/cards/classic/paladin/minion_aldor_peacekeeper.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "SetAttackSpell",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/paladin/minion_argent_protector.json
+++ b/cards/src/main/resources/cards/classic/paladin/minion_argent_protector.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "AddAttributeSpell",
 			"attribute": "DIVINE_SHIELD"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/priest/minion_cabal_shadow_priest.json
+++ b/cards/src/main/resources/cards/classic/priest/minion_cabal_shadow_priest.json
@@ -18,8 +18,7 @@
 				"operation": "LESS_OR_EQUAL",
 				"value": 2
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/priest/minion_temple_enforcer.json
+++ b/cards/src/main/resources/cards/classic/priest/minion_temple_enforcer.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "BuffSpell",
 			"hpBonus": 3
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/rogue/minion_defias_ringleader.json
+++ b/cards/src/main/resources/cards/classic/rogue/minion_defias_ringleader.json
@@ -16,8 +16,7 @@
 		},
 		"condition": {
 			"class": "ComboCondition"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"COMBO": true

--- a/cards/src/main/resources/cards/classic/rogue/minion_edwin_vancleef.json
+++ b/cards/src/main/resources/cards/classic/rogue/minion_edwin_vancleef.json
@@ -18,8 +18,7 @@
 				"attribute": "COMBO",
 				"multiplier": 2
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"COMBO": true

--- a/cards/src/main/resources/cards/classic/rogue/minion_kidnapper.json
+++ b/cards/src/main/resources/cards/classic/rogue/minion_kidnapper.json
@@ -15,8 +15,7 @@
 		},
 		"condition": {
 			"class": "ComboCondition"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"COMBO": true

--- a/cards/src/main/resources/cards/classic/rogue/minion_master_of_disguise.json
+++ b/cards/src/main/resources/cards/classic/rogue/minion_master_of_disguise.json
@@ -17,8 +17,7 @@
 				"class": "TurnStartTrigger",
 				"targetPlayer": "SELF"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/rogue/minion_si7_agent.json
+++ b/cards/src/main/resources/cards/classic/rogue/minion_si7_agent.json
@@ -16,8 +16,7 @@
 		},
 		"condition": {
 			"class": "ComboCondition"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"COMBO": true

--- a/cards/src/main/resources/cards/classic/rogue/weapon_perditions_blade.json
+++ b/cards/src/main/resources/cards/classic/rogue/weapon_perditions_blade.json
@@ -21,8 +21,7 @@
 				"class": "DamageSpell",
 				"value": 2
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/classic/warlock/minion_doomguard.json
+++ b/cards/src/main/resources/cards/classic/warlock/minion_doomguard.json
@@ -14,8 +14,7 @@
 		"spell": {
 			"class": "DiscardSpell",
 			"value": 2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/classic/warlock/minion_felguard.json
+++ b/cards/src/main/resources/cards/classic/warlock/minion_felguard.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "ModifyMaxManaSpell",
 			"value": -1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/classic/warlock/minion_flame_imp.json
+++ b/cards/src/main/resources/cards/classic/warlock/minion_flame_imp.json
@@ -14,8 +14,7 @@
 			"class": "DamageSpell",
 			"target": "FRIENDLY_HERO",
 			"value": 3
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/warlock/minion_lord_jaraxxus.json
+++ b/cards/src/main/resources/cards/classic/warlock/minion_lord_jaraxxus.json
@@ -30,8 +30,7 @@
 					"target": "FRIENDLY_HERO" 
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/warlock/minion_lord_jaraxxus.json
+++ b/cards/src/main/resources/cards/classic/warlock/minion_lord_jaraxxus.json
@@ -22,21 +22,16 @@
 					"card": "hero_jaraxxus"
 				},
 				{
-					"class": "SetHeroHpSpell",
-					"target": "FRIENDLY_HERO",
-					"value": {
-						"class": "AttributeValueProvider",
-						"target": "SELF",
-						"attribute": "HP"
-					}
-				},
-				{
 					"class": "EquipWeaponSpell",
 					"card": "weapon_blood_fury"
+				},
+				{
+					"class": "OverrideTargetSpell",
+					"target": "FRIENDLY_HERO" 
 				}
 			]
 		},
-		"resolvedLate": true
+		"resolvedLate": false
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/warlock/minion_pit_lord.json
+++ b/cards/src/main/resources/cards/classic/warlock/minion_pit_lord.json
@@ -14,8 +14,7 @@
 			"class": "DamageSpell",
 			"target": "FRIENDLY_HERO",
 			"value": 5
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/warlock/minion_void_terror.json
+++ b/cards/src/main/resources/cards/classic/warlock/minion_void_terror.json
@@ -33,8 +33,7 @@
 					"target": "ADJACENT_MINIONS"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/warrior/minion_arathi_weaponsmith.json
+++ b/cards/src/main/resources/cards/classic/warrior/minion_arathi_weaponsmith.json
@@ -12,8 +12,7 @@
 		"spell": {
 			"class": "EquipWeaponSpell",
 			"card": "weapon_battle_axe"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/classic/warrior/minion_cruel_taskmaster.json
+++ b/cards/src/main/resources/cards/classic/warrior/minion_cruel_taskmaster.json
@@ -22,8 +22,7 @@
 					"value": 1
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/druid/minion_druid_of_the_fang.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/druid/minion_druid_of_the_fang.json
@@ -17,8 +17,7 @@
 		"condition": {
 			"class": "RaceOnBoardCondition",
 			"race": "BEAST"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/hunter/minion_king_of_beasts.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/hunter/minion_king_of_beasts.json
@@ -21,8 +21,7 @@
 					"race": "BEAST"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/hunter/minion_metaltooth_leaper.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/hunter/minion_metaltooth_leaper.json
@@ -18,8 +18,7 @@
 				"class": "RaceFilter",
 				"race": "MECH"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/hunter/weapon_glaivezooka.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/hunter/weapon_glaivezooka.json
@@ -15,8 +15,7 @@
 			"target": "FRIENDLY_MINIONS",
 			"attackBonus": 1,
 			"randomTarget": "true"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/mage/minion_goblin_blastmage.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/mage/minion_goblin_blastmage.json
@@ -17,8 +17,7 @@
 		"condition": {
 			"class": "RaceOnBoardCondition",
 			"race": "MECH"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_antique_healbot.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_antique_healbot.json
@@ -14,8 +14,7 @@
 			"class": "HealSpell",
 			"target": "FRIENDLY_HERO",
 			"value": 8
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_blingtron_3000.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_blingtron_3000.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "EquipRandomWeaponSpell",
 			"targetPlayer": "BOTH"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_bomb_lobber.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_bomb_lobber.json
@@ -14,8 +14,7 @@
 			"target": "ENEMY_MINIONS",
 			"value": 4,
 			"howMany": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_dr_boom.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_dr_boom.json
@@ -23,8 +23,7 @@
 					"boardPositionRelative": "LEFT"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_enhance-o_mechano.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_enhance-o_mechano.json
@@ -27,8 +27,7 @@
 					"attribute": "DIVINE_SHIELD"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_gnomish_experimenter.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_gnomish_experimenter.json
@@ -22,8 +22,7 @@
 					"cardType": "MINION"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_hemet_nesingwary.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_hemet_nesingwary.json
@@ -16,8 +16,7 @@
 				"class": "RaceFilter",
 				"race": "BEAST"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_kezan_mystic.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_kezan_mystic.json
@@ -11,8 +11,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "StealRandomSecretSpell"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_lil_exorcist.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_lil_exorcist.json
@@ -17,8 +17,7 @@
 				"target": "ENEMY_MINIONS",
 				"attribute": "DEATHRATTLES"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_madder_bomber.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_madder_bomber.json
@@ -14,8 +14,7 @@
 			"target": "ALL_OTHER_CHARACTERS",
 			"value": 1,
 			"howMany": 6
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_recombobulator.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_recombobulator.json
@@ -20,8 +20,7 @@
 					"attribute": "BASE_MANA_COST"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_tinkertown_technician.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_tinkertown_technician.json
@@ -35,8 +35,7 @@
 		"condition": {
 			"class": "RaceOnBoardCondition",
 			"race": "MECH"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_toshley.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/neutral/minion_toshley.json
@@ -20,8 +20,7 @@
 				"spell_time_rewinder",
 				"spell_whirling_blades"
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"deathrattle": {
 		"class": "ReceiveRandomCardSpell",

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/paladin/minion_quartermaster.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/paladin/minion_quartermaster.json
@@ -18,8 +18,7 @@
 				"class": "SpecificCardFilter",
 				"cardId": "token_silver_hand_recruit"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/paladin/minion_scarlet_purifier.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/paladin/minion_scarlet_purifier.json
@@ -18,8 +18,7 @@
 				"attribute": "DEATHRATTLES",
 				"operation": "HAS"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/paladin/weapon_coghammer.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/paladin/weapon_coghammer.json
@@ -24,8 +24,7 @@
 				}
 			],
 			"randomTarget": true
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/priest/minion_shadowbomber.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/priest/minion_shadowbomber.json
@@ -23,8 +23,7 @@
 					"value": 3
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/priest/minion_shrinkmeister.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/priest/minion_shrinkmeister.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "TemporaryAttackSpell",
 			"value": -2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/priest/minion_upgraded_repair_bot.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/priest/minion_upgraded_repair_bot.json
@@ -18,8 +18,7 @@
 				"class": "RaceFilter",
 				"race": "MECH"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/rogue/minion_goblin_auto-barber.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/rogue/minion_goblin_auto-barber.json
@@ -14,8 +14,7 @@
 			"class": "BuffWeaponSpell",
 			"target": "FRIENDLY_WEAPON",
 			"attackBonus": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/shaman/minion_neptulon.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/shaman/minion_neptulon.json
@@ -16,8 +16,7 @@
 				"class": "RaceFilter",
 				"race": "MURLOC"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/minion_iron_juggernaut.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/minion_iron_juggernaut.json
@@ -14,8 +14,7 @@
 			"class": "ShuffleToDeckSpell",
 			"targetPlayer": "OPPONENT",
 			"card": "spell_burrowing_mine"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/minion_screwjank_clunker.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/minion_screwjank_clunker.json
@@ -19,8 +19,7 @@
 				"class": "RaceFilter",
 				"race": "MECH"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/minion_shieldmaiden.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/minion_shieldmaiden.json
@@ -13,8 +13,7 @@
 			"class": "BuffHeroSpell",
 			"target": "FRIENDLY_HERO",
 			"armorBonus": 5
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_ancient_shade.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_ancient_shade.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "ShuffleToDeckSpell",
 			"card": "spell_ancient_curse"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_archthief_rafaam.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_archthief_rafaam.json
@@ -20,8 +20,7 @@
 			"spell": {
 				"class": "ReceiveCardSpell"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_dark_peddler.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_dark_peddler.json
@@ -20,8 +20,7 @@
 				"class": "CardFilter",
 				"manaCost": 1
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_desert_camel.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_desert_camel.json
@@ -20,8 +20,7 @@
 				"cardType": "MINION",
 				"manaCost": 1
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_elise_starseeker.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_elise_starseeker.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "ShuffleToDeckSpell",
 			"card": "spell_map_to_the_golden_monkey"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_ethereal_conjurer.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_ethereal_conjurer.json
@@ -20,8 +20,7 @@
 				"class": "CardFilter",
 				"cardType": "SPELL"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_fossilized_devilsaur.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_fossilized_devilsaur.json
@@ -18,8 +18,7 @@
 		"condition": {
 			"class": "RaceOnBoardCondition",
 			"race": "BEAST"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_gorillabot_a3.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_gorillabot_a3.json
@@ -26,8 +26,7 @@
 		"condition": {
 			"class": "RaceOnBoardCondition",
 			"race": "MECH"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_jeweled_scarab.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_jeweled_scarab.json
@@ -21,8 +21,7 @@
 				"class": "CardFilter",
 				"manaCost": 3
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_keeper_of_uldaman.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_keeper_of_uldaman.json
@@ -22,8 +22,7 @@
 					"value": 3
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_museum_curator.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_museum_curator.json
@@ -21,8 +21,7 @@
 				"attribute": "DEATHRATTLES",
 				"operation": "HAS"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_reliquary_seeker.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_reliquary_seeker.json
@@ -21,8 +21,7 @@
 			"targetPlayer": "SELF",
 			"operation": "EQUAL",
 			"value": 7
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_reno_jackson.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_reno_jackson.json
@@ -20,8 +20,7 @@
 		},
 		"condition": {
 			"class": "HighlanderDeckCondition"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_sir_finley_mrrgglton.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_sir_finley_mrrgglton.json
@@ -29,8 +29,7 @@
 				"targetPlayer": "SELF"
 			},
 			"cannotReceiveOwned": true
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_tomb_spider.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_tomb_spider.json
@@ -21,8 +21,7 @@
 				"class": "CardFilter",
 				"race": "BEAST"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/minion_unearthed_raptor.json
+++ b/cards/src/main/resources/cards/league_of_explorers/minion_unearthed_raptor.json
@@ -17,8 +17,7 @@
 				"attribute": "DEATHRATTLES",
 				"operation": "HAS"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/league_of_explorers/token_golden_monkey.json
+++ b/cards/src/main/resources/cards/league_of_explorers/token_golden_monkey.json
@@ -32,8 +32,7 @@
 					}
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/naxxramas/minion_echoing_ooze.json
+++ b/cards/src/main/resources/cards/naxxramas/minion_echoing_ooze.json
@@ -22,8 +22,7 @@
 				},
 				"oneTurn": true
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/naxxramas/minion_loatheb.json
+++ b/cards/src/main/resources/cards/naxxramas/minion_loatheb.json
@@ -23,8 +23,7 @@
 					"targetPlayer": "OPPONENT"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/naxxramas/minion_wailing_soul.json
+++ b/cards/src/main/resources/cards/naxxramas/minion_wailing_soul.json
@@ -12,8 +12,7 @@
 		"spell": {
 			"class": "SilenceSpell",
 			"target": "OTHER_FRIENDLY_MINIONS"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/promo/minion_elite_tauren_chieftain.json
+++ b/cards/src/main/resources/cards/promo/minion_elite_tauren_chieftain.json
@@ -17,8 +17,7 @@
 				"spell_power_of_the_horde",
 				"spell_rogues_do_it"
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/promo/minion_gelbin_mekkatorque.json
+++ b/cards/src/main/resources/cards/promo/minion_gelbin_mekkatorque.json
@@ -17,8 +17,7 @@
 				"token_poultryizer",
 				"token_repair_bot"
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/reward/minion_captains_parrot.json
+++ b/cards/src/main/resources/cards/reward/minion_captains_parrot.json
@@ -17,8 +17,7 @@
 				"class": "CardFilter",
 				"race": "PIRATE"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/druid/minion_darnassus_aspirant.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/druid/minion_darnassus_aspirant.json
@@ -12,8 +12,7 @@
 		"spell": {
 			"class": "ModifyMaxManaSpell",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"deathrattle": {
 		"class": "ModifyMaxManaSpell",

--- a/cards/src/main/resources/cards/the_grand_tournament/druid/minion_wildwalker.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/druid/minion_wildwalker.json
@@ -17,8 +17,7 @@
 				"class": "RaceFilter",
 				"race": "BEAST"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/hunter/minion_kings_elekk.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/hunter/minion_kings_elekk.json
@@ -15,8 +15,7 @@
 			"spell": {
 				"class": "FromDeckToHandSpell"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/hunter/minion_ram_wrangler.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/hunter/minion_ram_wrangler.json
@@ -20,8 +20,7 @@
 		"condition": {
 			"class": "RaceOnBoardCondition",
 			"race": "BEAST"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/hunter/minion_stablemaster.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/hunter/minion_stablemaster.json
@@ -20,8 +20,7 @@
 			"revertTrigger": {
 				"class": "TurnEndTrigger"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/mage/minion_spellslinger.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/mage/minion_spellslinger.json
@@ -17,8 +17,7 @@
 				"class": "CardFilter",
 				"cardType": "SPELL"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_armored_warhorse.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_armored_warhorse.json
@@ -18,8 +18,7 @@
 				"target": "SELF",
 				"attribute": "CHARGE"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_clockwork_knight.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_clockwork_knight.json
@@ -19,8 +19,7 @@
 				"class": "RaceFilter",
 				"race": "MECH"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_fencing_coach.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_fencing_coach.json
@@ -22,8 +22,7 @@
 					"targetPlayer": "SELF"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_flame_juggler.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_flame_juggler.json
@@ -15,8 +15,7 @@
 			"target": "ENEMY_CHARACTERS",
 			"value": 1,
 			"howMany": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_gadgetzan_jouster.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_gadgetzan_jouster.json
@@ -18,8 +18,7 @@
 				"attackBonus": 1,
 				"hpBonus": 1
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_gormok_the_impaler.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_gormok_the_impaler.json
@@ -19,8 +19,7 @@
 			"targetPlayer": "SELF",
 			"operation": "GREATER",
 			"value": 4
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_grand_crusader.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_grand_crusader.json
@@ -15,8 +15,7 @@
 				"class": "CardFilter",
 				"heroClass": "PALADIN"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_injured_kvaldir.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_injured_kvaldir.json
@@ -13,8 +13,7 @@
 			"class": "DamageSpell",
 			"target": "SELF",
 			"value": 3
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_justicar_trueheart.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_justicar_trueheart.json
@@ -88,8 +88,7 @@
 					"cardId": "hero_power_armor_up"
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_lance_carrier.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_lance_carrier.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "BuffSpell",
 			"attackBonus": 2
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_lights_champion.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_lights_champion.json
@@ -16,8 +16,7 @@
 				"class": "RaceFilter",
 				"race": "DEMON"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_master_jouster.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_master_jouster.json
@@ -27,8 +27,7 @@
 					}
 				]
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_master_of_ceremonies.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_master_of_ceremonies.json
@@ -23,8 +23,7 @@
 				"attribute": "SPELL_DAMAGE",
 				"operation": "HAS"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_north_sea_kraken.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_north_sea_kraken.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "DamageSpell",
 			"value": 4
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_refreshment_vendor.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_refreshment_vendor.json
@@ -23,8 +23,7 @@
 					"value": 4
 				}
 			]
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_saboteur.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_saboteur.json
@@ -23,8 +23,7 @@
 					"targetPlayer": "OPPONENT"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_sideshow_spelleater.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_sideshow_spelleater.json
@@ -12,8 +12,7 @@
 		"spell": {
 			"class": "CopyHeroPower",
 			"target": "FRIENDLY_HERO"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_twilight_guardian.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_twilight_guardian.json
@@ -27,8 +27,7 @@
 		"condition": {
 			"class": "HoldsCardCondition",
 			"race": "DRAGON"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/paladin/minion_eadric_the_pure.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/paladin/minion_eadric_the_pure.json
@@ -13,8 +13,7 @@
 			"class": "SetAttackSpell",
 			"target": "ENEMY_MINIONS",
 			"value": 1
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/paladin/minion_mysterious_challenger.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/paladin/minion_mysterious_challenger.json
@@ -12,8 +12,7 @@
 		"spell": {
 			"class": "PutRandomSecretIntoPlaySpell",
 			"howMany": 99
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/paladin/minion_tuskarr_jouster.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/paladin/minion_tuskarr_jouster.json
@@ -16,8 +16,7 @@
 				"target": "FRIENDLY_HERO",
 				"value": 7
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/paladin/weapon_argent_lance.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/paladin/weapon_argent_lance.json
@@ -17,8 +17,7 @@
 				"targetPlayer": "SELF",
 				"value": 1
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/priest/minion_wyrmrest_agent.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/priest/minion_wyrmrest_agent.json
@@ -26,8 +26,7 @@
 		"condition": {
 			"class": "HoldsCardCondition",
 			"race": "DRAGON"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/rogue/minion_shado-pan_rider.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/rogue/minion_shado-pan_rider.json
@@ -17,8 +17,7 @@
 		},
 		"condition": {
 			"class": "ComboCondition"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"COMBO": true

--- a/cards/src/main/resources/cards/the_grand_tournament/rogue/minion_shady_dealer.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/rogue/minion_shady_dealer.json
@@ -18,8 +18,7 @@
 		"condition": {
 			"class": "RaceOnBoardCondition",
 			"race": "PIRATE"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/rogue/minion_undercity_valiant.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/rogue/minion_undercity_valiant.json
@@ -16,8 +16,7 @@
 		},
 		"condition": {
 			"class": "ComboCondition"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"COMBO": true

--- a/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_draenei_totemcarver.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_draenei_totemcarver.json
@@ -20,8 +20,7 @@
 					"race": "TOTEM"
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_the_mistcaller.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_the_mistcaller.json
@@ -38,8 +38,7 @@
 						}
 					}
 				}
-			],
-			"resolvedLate": false
+			]
 		}
 	},
 	"attributes": {

--- a/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_tuskarr_totemic.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_tuskarr_totemic.json
@@ -18,8 +18,7 @@
 				"cardType": "MINION",
 				"race": "TOTEM"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/warrior/minion_alexstraszas_champion.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/warrior/minion_alexstraszas_champion.json
@@ -26,8 +26,7 @@
 		"condition": {
 			"class": "HoldsCardCondition",
 			"race": "DRAGON"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/warrior/minion_sparring_partner.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/warrior/minion_sparring_partner.json
@@ -13,8 +13,7 @@
 		"spell": {
 			"class": "AddAttributeSpell",
 			"attribute": "TAUNT"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true,

--- a/cards/src/main/resources/cards/the_grand_tournament/warrior/minion_varian_wrynn.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/warrior/minion_varian_wrynn.json
@@ -33,8 +33,7 @@
 					]
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_grand_tournament/warrior/weapon_kings_defender.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/warrior/weapon_kings_defender.json
@@ -23,8 +23,7 @@
 				"attribute": "TAUNT",
 				"operation": "HAS"
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_old_gods/shaman/minion_master_of_evolution.json
+++ b/cards/src/main/resources/cards/the_old_gods/shaman/minion_master_of_evolution.json
@@ -21,8 +21,7 @@
 					"offset": 1
 				}
 			}
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/cards/src/main/resources/cards/the_old_gods/warrior/minion_nzoths_first_mate.json
+++ b/cards/src/main/resources/cards/the_old_gods/warrior/minion_nzoths_first_mate.json
@@ -12,8 +12,7 @@
 		"spell": {
 			"class": "EquipWeaponSpell",
 			"card": "weapon_rusty_hook"
-		},
-		"resolvedLate": false
+		}
 	},
 	"attributes": {
 		"BATTLECRY": true

--- a/game/src/main/java/net/demilich/metastone/game/actions/BattlecryAction.java
+++ b/game/src/main/java/net/demilich/metastone/game/actions/BattlecryAction.java
@@ -24,7 +24,6 @@ public class BattlecryAction extends GameAction {
 	}
 
 	private final SpellDesc spell;
-	private boolean resolvedLate = false;
 	private Condition condition;
 
 	protected BattlecryAction(SpellDesc spell) {
@@ -57,7 +56,6 @@ public class BattlecryAction extends GameAction {
 	public BattlecryAction clone() {
 		BattlecryAction clone = BattlecryAction.createBattlecry(getSpell(), getTargetRequirement());
 		clone.setActionSuffix(getActionSuffix());
-		clone.setResolvedLate(isResolvedLate());
 		clone.setSource(getSource());
 		return clone;
 	}
@@ -85,10 +83,6 @@ public class BattlecryAction extends GameAction {
 		return spell;
 	}
 
-	public boolean isResolvedLate() {
-		return resolvedLate;
-	}
-
 	@Override
 	public boolean isSameActionGroup(GameAction anotherAction) {
 		return anotherAction.getActionType() == getActionType();
@@ -102,12 +96,8 @@ public class BattlecryAction extends GameAction {
 		// this.entityFilter = entityFilter;
 	}
 
-	public void setResolvedLate(boolean resolvedLate) {
-		this.resolvedLate = resolvedLate;
-	}
-
 	@Override
 	public String toString() {
-		return String.format("[%s '%s' resolvedLate:%s]", getActionType(), getSpell().getSpellClass().getSimpleName(), resolvedLate);
+		return String.format("[%s '%s']", getActionType(), getSpell().getSpellClass().getSimpleName());
 	}
 }

--- a/game/src/main/java/net/demilich/metastone/game/cards/MinionCard.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/MinionCard.java
@@ -49,7 +49,6 @@ public class MinionCard extends Card {
 		BattlecryDesc battlecry = desc.battlecry;
 		if (battlecry != null) {
 			BattlecryAction battlecryAction = BattlecryAction.createBattlecry(battlecry.spell, battlecry.getTargetSelection());
-			battlecryAction.setResolvedLate(battlecry.resolvedLate);
 			if (battlecry.condition != null) {
 				battlecryAction.setCondition(battlecry.condition.create());
 			}

--- a/game/src/main/java/net/demilich/metastone/game/cards/WeaponCard.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/WeaponCard.java
@@ -46,7 +46,6 @@ public class WeaponCard extends Card {
 		BattlecryDesc battlecry = desc.battlecry;
 		if (battlecry != null) {
 			BattlecryAction battlecryAction = BattlecryAction.createBattlecry(battlecry.spell, battlecry.getTargetSelection());
-			battlecryAction.setResolvedLate(battlecry.resolvedLate);
 			if (battlecry.condition != null) {
 				battlecryAction.setCondition(battlecry.condition.create());
 			}

--- a/game/src/main/java/net/demilich/metastone/game/events/SummonEvent.java
+++ b/game/src/main/java/net/demilich/metastone/game/events/SummonEvent.java
@@ -2,15 +2,15 @@ package net.demilich.metastone.game.events;
 
 import net.demilich.metastone.game.GameContext;
 import net.demilich.metastone.game.cards.Card;
+import net.demilich.metastone.game.entities.Actor;
 import net.demilich.metastone.game.entities.Entity;
-import net.demilich.metastone.game.entities.minions.Minion;
 
 public class SummonEvent extends GameEvent {
 
-	private final Minion minion;
+	private final Actor minion;
 	private final Card source;
 
-	public SummonEvent(GameContext context, Minion minion, Card source) {
+	public SummonEvent(GameContext context, Actor minion, Card source) {
 		super(context, minion.getOwner(), -1);
 		this.minion = minion;
 		this.source = source;
@@ -26,7 +26,7 @@ public class SummonEvent extends GameEvent {
 		return GameEventType.SUMMON;
 	}
 
-	public Minion getMinion() {
+	public Actor getMinion() {
 		return minion;
 	}
 

--- a/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
@@ -1644,8 +1644,15 @@ public class GameLogic implements Cloneable {
 		context.fireGameEvent(new BoardChangedEvent(context));
 
 		player.getStatistics().minionSummoned(minion);
-		SummonEvent summonEvent = new SummonEvent(context, minion, source);
-		context.fireGameEvent(summonEvent);
+		if (context.getEnvironment().get(Environment.TARGET_OVERRIDE) != null) {
+			Actor actor = (Actor) context.resolveSingleTarget((EntityReference) context.getEnvironment().get(Environment.TARGET_OVERRIDE));
+			context.getEnvironment().remove(Environment.TARGET_OVERRIDE);
+			SummonEvent summonEvent = new SummonEvent(context, actor, source);
+			context.fireGameEvent(summonEvent);
+		} else {
+			SummonEvent summonEvent = new SummonEvent(context, minion, source);
+			context.fireGameEvent(summonEvent);
+		}
 
 		applyAttribute(minion, Attribute.SUMMONING_SICKNESS);
 		refreshAttacksPerRound(minion);

--- a/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
@@ -1630,7 +1630,7 @@ public class GameLogic implements Cloneable {
 			player.getMinions().add(index, minion);
 		}
 
-		if (resolveBattlecry && minion.getBattlecry() != null && !minion.getBattlecry().isResolvedLate()) {
+		if (resolveBattlecry && minion.getBattlecry() != null) {
 			resolveBattlecry(player.getId(), minion);
 			checkForDeadEntities();
 		}
@@ -1663,11 +1663,6 @@ public class GameLogic implements Cloneable {
 
 		if (minion.getCardCostModifier() != null) {
 			addManaModifier(player, minion.getCardCostModifier(), minion);
-		}
-
-		if (resolveBattlecry && minion.getBattlecry() != null && minion.getBattlecry().isResolvedLate()) {
-			resolveBattlecry(player.getId(), minion);
-			checkForDeadEntities();
 		}
 
 		handleEnrage(minion);

--- a/game/src/main/java/net/demilich/metastone/game/spells/CloneMinionSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/CloneMinionSpell.java
@@ -2,7 +2,9 @@ package net.demilich.metastone.game.spells;
 
 import net.demilich.metastone.game.GameContext;
 import net.demilich.metastone.game.Player;
+import net.demilich.metastone.game.cards.MinionCard;
 import net.demilich.metastone.game.entities.Entity;
+import net.demilich.metastone.game.entities.heroes.Hero;
 import net.demilich.metastone.game.entities.minions.Minion;
 import net.demilich.metastone.game.spells.desc.SpellDesc;
 
@@ -10,6 +12,9 @@ public class CloneMinionSpell extends Spell {
 
 	@Override
 	protected void onCast(GameContext context, Player player, SpellDesc desc, Entity source, Entity target) {
+		if (target instanceof Hero) {
+			target = ((MinionCard) context.getPendingCard()).summon();
+		}
 		Minion template = (Minion) target;
 		Minion clone = template.clone();
 

--- a/game/src/main/java/net/demilich/metastone/game/spells/OverrideTargetSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/OverrideTargetSpell.java
@@ -1,0 +1,24 @@
+package net.demilich.metastone.game.spells;
+
+import java.util.Map;
+
+import net.demilich.metastone.game.Environment;
+import net.demilich.metastone.game.GameContext;
+import net.demilich.metastone.game.Player;
+import net.demilich.metastone.game.entities.Entity;
+import net.demilich.metastone.game.spells.desc.SpellArg;
+import net.demilich.metastone.game.spells.desc.SpellDesc;
+
+public class OverrideTargetSpell extends Spell {
+
+	public static SpellDesc create() {
+		Map<SpellArg, Object> arguments = SpellDesc.build(OverrideTargetSpell.class);
+		return new SpellDesc(arguments);
+	}
+
+	@Override
+	protected void onCast(GameContext context, Player player, SpellDesc desc, Entity source, Entity target) {
+		context.getEnvironment().put(Environment.TARGET_OVERRIDE, target.getReference());
+	}
+
+}

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/BattlecryDesc.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/BattlecryDesc.java
@@ -8,7 +8,6 @@ public class BattlecryDesc {
 	public SpellDesc spell;
 	public TargetSelection targetSelection;
 	public ConditionDesc condition;
-	public boolean resolvedLate;
 	public String description;
 
 	public TargetSelection getTargetSelection() {


### PR DESCRIPTION
- Fixed Jaraxxus to properly interact with secrets (Snipe, Mirror Entity, Repentance, Sacred Trial, and any more that might ever be made.)
- Removed the resolvedLate tag from all cards.
- Removed resolvedLate references from files.