### PR TITLE
Added RC Versioning

### DIFF
--- a/shared/src/main/java/net/demilich/metastone/utils/VersionInfo.java
+++ b/shared/src/main/java/net/demilich/metastone/utils/VersionInfo.java
@@ -4,7 +4,8 @@ public class VersionInfo {
 
 	private static final int MAJOR_INDEX = 0;
 	private static final int MINOR_INDEX = 1;
-	private static final int REVESION_INDEX = 2;
+	private static final int REVISION_INDEX = 2;
+	private static final int RELEASE_INDEX = 3;
 
 	public String version;
 	public String[] whatsNew;
@@ -25,18 +26,40 @@ public class VersionInfo {
 			return true;
 		}
 		if (remoteVersion[MAJOR_INDEX] == localVersion[MAJOR_INDEX] && remoteVersion[MINOR_INDEX] == localVersion[MINOR_INDEX]
-				&& remoteVersion[REVESION_INDEX] > localVersion[REVESION_INDEX]) {
+				&& remoteVersion[REVISION_INDEX] > localVersion[REVISION_INDEX]) {
+			return true;
+		}
+		if (remoteVersion[MAJOR_INDEX] == localVersion[MAJOR_INDEX] && remoteVersion[MINOR_INDEX] == localVersion[MINOR_INDEX]
+				&& remoteVersion[REVISION_INDEX] == localVersion[REVISION_INDEX] && remoteVersion.length == RELEASE_INDEX
+				&& localVersion.length > RELEASE_INDEX) {
+			return true;
+		}
+		if (remoteVersion.length > RELEASE_INDEX && localVersion.length > RELEASE_INDEX
+				&& remoteVersion[MAJOR_INDEX] == localVersion[MAJOR_INDEX] && remoteVersion[MINOR_INDEX] == localVersion[MINOR_INDEX]
+				&& remoteVersion[REVISION_INDEX] == localVersion[REVISION_INDEX] && remoteVersion[RELEASE_INDEX] > localVersion[RELEASE_INDEX]) {
 			return true;
 		}
 		return false;
 	}
 
 	private static Integer[] parseVersionString(String rawVersionString) {
-		String versionString = rawVersionString.replaceAll("[^\\d+|^\\.]", "");
+		String versionString = rawVersionString.replaceAll("[^\\d+|^\\.RC]", "");
+		String[] releaseVersion = versionString.split("RC");
 		String[] parts = versionString.split("\\.");
-		Integer[] versions = new Integer[parts.length];
-		for (int i = 0; i < versions.length; i++) {
-			versions[i] = Integer.parseInt(parts[i]);
+		Integer[] versions;
+		if (releaseVersion.length > 1) {
+			parts = releaseVersion[0].split("\\.");
+			versions = new Integer[parts.length + 1];
+			for (int i = 0; i < parts.length; i++) {
+				versions[i] = Integer.parseInt(parts[i]);
+			}
+			versions[RELEASE_INDEX] = Integer.parseInt(releaseVersion[1]);
+		} else {
+			parts = versionString.split("\\.");
+			versions = new Integer[parts.length];
+			for (int i = 0; i < versions.length; i++) {
+				versions[i] = Integer.parseInt(parts[i]);
+			}
 		}
 		return versions;
 	}


### PR DESCRIPTION
- Release candidates can now have their versions included.

In order to use this PR, you will need to update the version number to 1.2.1 or higher for this to take effect. What this allows is the use of versioning release candidates. For example, 1.2.0RC2 would replace cards in 1.2.0RC1, but 1.2.0 would replace cards in 1.2.0RC2. This means that every release candidate can be versioned correctly, and still have the public release be usable. Since release candidates currently use the version 1.2.0, updating the current version to 1.2.1 will be necessary. (1.2.1RC1 will be the next version.)