### PR TITLE
Feature Update

### DIFF
--- a/app/src/main/java/net/demilich/metastone/gui/sandboxmode/commands/PerformActionCommand.java
+++ b/app/src/main/java/net/demilich/metastone/gui/sandboxmode/commands/PerformActionCommand.java
@@ -30,7 +30,7 @@ public class PerformActionCommand extends SimpleCommand<GameNotification> {
 		if (rolledOutActions.isEmpty()) {
 			return;
 		}
-		if (gameAction.getTargetRequirement() != TargetSelection.NONE) {
+		if (gameAction.getTargetRequirement() != TargetSelection.NONE && gameAction.getTargetRequirement() != TargetSelection.AUTO) {
 			ActionGroup actionGroup = new ActionGroup(rolledOutActions.get(0));
 			for (GameAction rolledAction : rolledOutActions) {
 				actionGroup.add(rolledAction);

--- a/game/src/main/java/net/demilich/metastone/game/GameContext.java
+++ b/game/src/main/java/net/demilich/metastone/game/GameContext.java
@@ -252,6 +252,36 @@ public class GameContext implements Cloneable, IDisposable {
 	public Player getOpponent(Player player) {
 		return player.getId() == PLAYER_1 ? getPlayer2() : getPlayer1();
 	}
+
+	public List<Actor> getOppositeMinions(Player player, EntityReference minionReference) {
+		List<Actor> oppositeMinions = new ArrayList<>();
+		Actor minion = (Actor) resolveSingleTarget(minionReference);
+		Player owner = getPlayer(minion.getOwner());
+		Player opposingPlayer = getOpponent(owner);
+		int index = owner.getMinions().indexOf(minion);
+		if (opposingPlayer.getMinions().size() == 0 || owner.getMinions().size() == 0 || index == -1) {
+			return oppositeMinions;
+		}
+		List<Minion> opposingMinions = opposingPlayer.getMinions();
+		int delta = opposingPlayer.getMinions().size() - owner.getMinions().size();
+		if (delta % 2 == 0) {
+			delta /= 2;
+			int epsilon = delta + index;
+			if (epsilon > -1 && epsilon < opposingMinions.size()) {
+				oppositeMinions.add(opposingMinions.get(epsilon));
+			}
+		} else {
+			delta = (delta - 1) / 2;
+			int epsilon = delta + index;
+			if (epsilon > -1 && epsilon < opposingMinions.size()) {
+				oppositeMinions.add(opposingMinions.get(epsilon));
+			}
+			if (epsilon + 1 > -1 && epsilon + 1 < opposingMinions.size()) {
+				oppositeMinions.add(opposingMinions.get(epsilon + 1));
+			}
+		}
+		return oppositeMinions;
+	}
 	
 	public Card getPendingCard() {
 		return (Card) resolveSingleTarget((EntityReference) getEnvironment().get(Environment.PENDING_CARD));

--- a/game/src/main/java/net/demilich/metastone/game/GameContext.java
+++ b/game/src/main/java/net/demilich/metastone/game/GameContext.java
@@ -308,6 +308,13 @@ public class GameContext implements Cloneable, IDisposable {
 		return logic.getValidActions(activePlayer);
 	}
 
+	public List<GameAction> getValidAutoActions() {
+		if (gameDecided()) {
+			return new ArrayList<>();
+		}
+		return logic.getAutoActions(activePlayer);
+	}
+
 	public int getWinningPlayerId() {
 		return winner == null ? -1 : winner.getId();
 	}
@@ -353,6 +360,11 @@ public class GameContext implements Cloneable, IDisposable {
 			return false;
 		}
 
+		List<GameAction> autoActions = getValidAutoActions();
+		if (!autoActions.isEmpty()) {
+			performAction(activePlayer, autoActions.get(0));
+			return true;
+		}
 		List<GameAction> validActions = getValidActions();
 		if (validActions.size() == 0) {
 			endTurn();

--- a/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
@@ -209,6 +209,10 @@ public class ParseUtils {
 			return EntityReference.FRIENDLY_HAND;
 		case "enemy_hand":
 			return EntityReference.ENEMY_HAND;
+		case "leftmost_friendly_minion":
+			return EntityReference.LEFTMOST_FRIENDLY_MINION;
+		case "leftmost_enemy_minion":
+			return EntityReference.LEFTMOST_ENEMY_MINION;
 		default:
 			return null;
 		}

--- a/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
@@ -179,6 +179,8 @@ public class ParseUtils {
 			return EntityReference.OTHER_FRIENDLY_MINIONS;
 		case "adjacent_minions":
 			return EntityReference.ADJACENT_MINIONS;
+		case "opposite_minions":
+			return EntityReference.OPPOSITE_MINIONS;
 		case "friendly_hero":
 			return EntityReference.FRIENDLY_HERO;
 		case "friendly_weapon":

--- a/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
@@ -265,7 +265,7 @@ public class GameLogic implements Cloneable {
 				spellCard = (SpellCard) sourceCard;
 			}
 
-			if (spellCard != null && spellCard.getTargetRequirement() != TargetSelection.NONE && !childSpell) {
+			if (spellCard != null && (spellCard.getTargetRequirement() != TargetSelection.NONE && spellCard.getTargetRequirement() != TargetSelection.AUTO) && !childSpell) {
 				GameEvent spellTargetEvent = new TargetAcquisitionEvent(context, playerId, ActionType.SPELL, spellCard, targets.get(0));
 				context.fireGameEvent(spellTargetEvent);
 				Entity targetOverride = context
@@ -843,6 +843,11 @@ public class GameLogic implements Cloneable {
 		return total;
 	}
 
+	public List<GameAction> getAutoActions(int playerId) {
+		Player player = context.getPlayer(playerId);
+		return actionLogic.getAutoActions(context, player);
+	}
+
 	public List<GameAction> getValidActions(int playerId) {
 		Player player = context.getPlayer(playerId);
 		return actionLogic.getValidActions(context, player);
@@ -1189,7 +1194,7 @@ public class GameLogic implements Cloneable {
 		if (playerId != context.getActivePlayerId()) {
 			logger.warn("Player {} tries to perform an action, but it is not his turn!", context.getPlayer(playerId).getName());
 		}
-		if (action.getTargetRequirement() != TargetSelection.NONE) {
+		if (action.getTargetRequirement() != TargetSelection.NONE && action.getTargetRequirement() != TargetSelection.AUTO) {
 			Entity target = context.resolveSingleTarget(action.getTargetKey());
 			if (target != null) {
 				context.getEnvironment().put(Environment.TARGET, target.getReference());
@@ -1463,7 +1468,7 @@ public class GameLogic implements Cloneable {
 
 		GameAction battlecryAction = null;
 		battlecry.setSource(actor.getReference());
-		if (battlecry.getTargetRequirement() != TargetSelection.NONE) {
+		if (battlecry.getTargetRequirement() != TargetSelection.NONE && battlecry.getTargetRequirement() != TargetSelection.AUTO) {
 			List<Entity> validTargets = targetLogic.getValidTargets(context, player, battlecry);
 			if (validTargets.isEmpty()) {
 				return;

--- a/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
@@ -236,6 +236,8 @@ public class TargetLogic {
 			return targets;
 		} else if (targetKey == EntityReference.ADJACENT_MINIONS) {
 			return new ArrayList<>(context.getAdjacentMinions(player, source.getReference()));
+		} else if (targetKey == EntityReference.OPPOSITE_MINIONS) {
+			return new ArrayList<>(context.getOppositeMinions(player, source.getReference()));
 		} else if (targetKey == EntityReference.SELF) {
 			return singleTargetAsList(source);
 		} else if (targetKey == EntityReference.EVENT_TARGET) {

--- a/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
@@ -269,6 +269,19 @@ public class TargetLogic {
 			return new ArrayList<>(player.getHand().toList());
 		} else if (targetKey == EntityReference.ENEMY_HAND) {
 			return new ArrayList<>(context.getOpponent(player).getHand().toList());
+		} else if (targetKey == EntityReference.LEFTMOST_FRIENDLY_MINION) {
+			if (player.getMinions().size() > 0) {
+				return singleTargetAsList(player.getMinions().get(0));
+			} else {
+				return new ArrayList<>();
+			}
+		} else if (targetKey == EntityReference.LEFTMOST_ENEMY_MINION) {
+			Player opponent = context.getOpponent(player);
+			if (opponent.getMinions().size() > 0) {
+				return singleTargetAsList(opponent.getMinions().get(0));
+			} else {
+				return new ArrayList<>();
+			}
 		}
 
 		return singleTargetAsList(findEntity(context, targetKey));

--- a/game/src/main/java/net/demilich/metastone/game/spells/CastRandomSpellSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/CastRandomSpellSpell.java
@@ -82,7 +82,7 @@ public class CastRandomSpellSpell extends Spell {
 				BattlecryAction battlecry = BattlecryAction.createBattlecry(copyCard.getSpell(), copyCard.getTargetRequirement());
 				GameAction battlecryAction = null;
 				battlecry.setSource(copyCard.getReference());
-				if (battlecry.getTargetRequirement() != TargetSelection.NONE) {
+				if (battlecry.getTargetRequirement() != TargetSelection.NONE && battlecry.getTargetRequirement() != TargetSelection.AUTO) {
 					List<Entity> validTargets = context.getLogic().getValidTargets(player.getId(), battlecry);
 					if (validTargets.isEmpty()) {
 						continue;

--- a/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
+++ b/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
@@ -20,6 +20,8 @@ public class EntityReference {
 	public static final EntityReference ENEMY_WEAPON = new EntityReference(-15);
 	public static final EntityReference FRIENDLY_HAND = new EntityReference(-16);
 	public static final EntityReference ENEMY_HAND = new EntityReference(-17);
+	public static final EntityReference LEFTMOST_FRIENDLY_MINION = new EntityReference(-18);
+	public static final EntityReference LEFTMOST_ENEMY_MINION = new EntityReference(-19);
 	
 
 	public static final EntityReference TARGET = new EntityReference(-30);

--- a/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
+++ b/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
@@ -20,8 +20,9 @@ public class EntityReference {
 	public static final EntityReference ENEMY_WEAPON = new EntityReference(-15);
 	public static final EntityReference FRIENDLY_HAND = new EntityReference(-16);
 	public static final EntityReference ENEMY_HAND = new EntityReference(-17);
-	public static final EntityReference LEFTMOST_FRIENDLY_MINION = new EntityReference(-18);
-	public static final EntityReference LEFTMOST_ENEMY_MINION = new EntityReference(-19);
+	public static final EntityReference OPPOSITE_MINIONS = new EntityReference(-18);
+	public static final EntityReference LEFTMOST_FRIENDLY_MINION = new EntityReference(-19);
+	public static final EntityReference LEFTMOST_ENEMY_MINION = new EntityReference(-20);
 	
 
 	public static final EntityReference TARGET = new EntityReference(-30);

--- a/game/src/main/java/net/demilich/metastone/game/targeting/TargetSelection.java
+++ b/game/src/main/java/net/demilich/metastone/game/targeting/TargetSelection.java
@@ -11,5 +11,6 @@ public enum TargetSelection {
 	MINIONS,
 	HEROES,
 	ADJACENT_MINIONS,
+	AUTO,
 	ANY
 }


### PR DESCRIPTION
- Implemented Auto actions. Setting a Hero Power or Spell to targetSelection AUTO automatically uses that ability if they could cast that card or hero power (As seen in several Adventures.)
- Implemented leftmost minion targeting for enemies and friendlies. (As seen in several Adventures.)
- Implemented opposite minion targeting. Minions opposing the source minion will be targeted by the effect. (As seen in the Wizard Chess adventure.)