### PR TITLE
Player vs. Hero Entity Update

### DIFF
--- a/app/src/main/java/net/demilich/metastone/gui/playmode/HeroToken.java
+++ b/app/src/main/java/net/demilich/metastone/gui/playmode/HeroToken.java
@@ -82,10 +82,10 @@ public class HeroToken extends GameToken {
 		if (!player.getDeck().isEmpty()) {
 			cardsLabel.setText("Cards in deck: " + player.getDeck().getCount());
 		} else {
-			cardsLabel.setText("Fatigue: " + player.getHero().getAttributeValue(Attribute.FATIGUE));
+			cardsLabel.setText("Fatigue: " + player.getAttributeValue(Attribute.FATIGUE));
 		}
-		if (player.getHero().getAttributeValue(Attribute.OVERLOAD) > 0) {
-			manaLabel.setText("Mana: " + player.getMana() + "/" + player.getMaxMana() + "\nOver: " + player.getHero().getAttributeValue(Attribute.OVERLOAD));
+		if (player.getAttributeValue(Attribute.OVERLOAD) > 0) {
+			manaLabel.setText("Mana: " + player.getMana() + "/" + player.getMaxMana() + "\nOver: " + player.getAttributeValue(Attribute.OVERLOAD));
 		} else {
 			manaLabel.setText("Mana: " + player.getMana() + "/" + player.getMaxMana());
 		}

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_dragon_consort.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_dragon_consort.json
@@ -12,7 +12,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"cardType": "MINION",

--- a/cards/src/main/resources/cards/blackrock_mountain/minion_emperor_thaurissan.json
+++ b/cards/src/main/resources/cards/blackrock_mountain/minion_emperor_thaurissan.json
@@ -15,7 +15,7 @@
 		},
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"target": "FRIENDLY_HAND",

--- a/cards/src/main/resources/cards/classic/mage/minion_kirin_tor_mage.json
+++ b/cards/src/main/resources/cards/classic/mage/minion_kirin_tor_mage.json
@@ -11,7 +11,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "OneTurnCostModifier",
 				"cardType": "SPELL",

--- a/cards/src/main/resources/cards/classic/neutral/minion_millhouse_manastorm.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_millhouse_manastorm.json
@@ -11,7 +11,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"cardType": "SPELL",

--- a/cards/src/main/resources/cards/classic/rogue/minion_edwin_vancleef.json
+++ b/cards/src/main/resources/cards/classic/rogue/minion_edwin_vancleef.json
@@ -14,7 +14,7 @@
 			"target": "SELF",
 			"value": {
 				"class": "AttributeValueProvider",
-				"target": "FRIENDLY_HERO",
+				"target": "FRIENDLY_PLAYER",
 				"attribute": "COMBO",
 				"multiplier": 2
 			}

--- a/cards/src/main/resources/cards/classic/rogue/spell_headcrack.json
+++ b/cards/src/main/resources/cards/classic/rogue/spell_headcrack.json
@@ -16,7 +16,7 @@
 		},
 		"spell2": {
 			"class": "AddSpellTriggerSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"trigger": {
 				"eventTrigger": {
 					"class": "TurnEndTrigger",

--- a/cards/src/main/resources/cards/classic/rogue/spell_preparation.json
+++ b/cards/src/main/resources/cards/classic/rogue/spell_preparation.json
@@ -9,7 +9,7 @@
 	"targetSelection": "NONE",
 	"spell": {
 		"class": "CardCostModifierSpell",
-		"target": "FRIENDLY_HERO",
+		"target": "FRIENDLY_PLAYER",
 		"cardCostModifier": {
 			"class": "OneTurnCostModifier",
 			"cardType": "SPELL",

--- a/cards/src/main/resources/cards/classic/warrior/spell_commanding_shout.json
+++ b/cards/src/main/resources/cards/classic/warrior/spell_commanding_shout.json
@@ -21,7 +21,7 @@
 			},
 			{
 				"class": "AddSpellTriggerSpell",
-				"target": "FRIENDLY_HERO",
+				"target": "FRIENDLY_PLAYER",
 				"trigger": {
 					"eventTrigger": {
 						"class": "MinionSummonedTrigger",

--- a/cards/src/main/resources/cards/league_of_explorers/token_wily_runt.json
+++ b/cards/src/main/resources/cards/league_of_explorers/token_wily_runt.json
@@ -1,6 +1,6 @@
 {
 	"id": "token_wily_runt",
-	"name": "Wily_Runt",
+	"name": "Wily Runt",
 	"baseManaCost": 2,
 	"type": "MINION",
 	"baseAttack": 2,

--- a/cards/src/main/resources/cards/naxxramas/minion_loatheb.json
+++ b/cards/src/main/resources/cards/naxxramas/minion_loatheb.json
@@ -11,7 +11,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"cardType": "SPELL",

--- a/cards/src/main/resources/cards/one_night_in_karazhan/minion_ethereal_peddler.json
+++ b/cards/src/main/resources/cards/one_night_in_karazhan/minion_ethereal_peddler.json
@@ -12,7 +12,7 @@
 		"targetSelection": "NONE",
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardFilter": {
 				"class": "CardFilter",
 				"heroClasses": [

--- a/cards/src/main/resources/cards/the_grand_tournament/hunter/spell_lock_and_load.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/hunter/spell_lock_and_load.json
@@ -9,7 +9,7 @@
 	"targetSelection": "NONE",
 	"spell": {
 		"class": "AddSpellTriggerSpell",
-		"target": "FRIENDLY_HERO",
+		"target": "FRIENDLY_PLAYER",
 		"trigger": {
 			"eventTrigger": {
 				"class": "SpellCastedTrigger",

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_fencing_coach.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_fencing_coach.json
@@ -11,7 +11,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"cardType": "HERO_POWER",

--- a/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_saboteur.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/neutral/minion_saboteur.json
@@ -11,7 +11,7 @@
 	"battlecry": {
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"cardType": "HERO_POWER",

--- a/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_the_mistcaller.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/shaman/minion_the_mistcaller.json
@@ -24,7 +24,7 @@
 				},
 				{
 					"class": "AddSpellTriggerSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"trigger": {
 						"eventTrigger": {
 							"class": "CardDrawnTrigger",

--- a/cards/src/main/resources/cards/the_grand_tournament/warlock/minion_wilfred_fizzlebang.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/warlock/minion_wilfred_fizzlebang.json
@@ -16,7 +16,7 @@
 		},
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"target": "EVENT_TARGET",

--- a/cards/src/main/resources/cards/the_old_gods/druid/minion_dark_arakkoa.json
+++ b/cards/src/main/resources/cards/the_old_gods/druid/minion_dark_arakkoa.json
@@ -32,13 +32,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 3
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 3
 				}

--- a/cards/src/main/resources/cards/the_old_gods/druid/minion_klaxxi_amber-weaver.json
+++ b/cards/src/main/resources/cards/the_old_gods/druid/minion_klaxxi_amber-weaver.json
@@ -50,7 +50,7 @@
 					"operation": "GREATER_OR_EQUAL",
 					"value1": {
 						"class": "AttributeValueProvider",
-						"target": "FRIENDLY_HERO",
+						"target": "FRIENDLY_PLAYER",
 						"attribute": "CTHUN_ATTACK_BUFF"
 					},
 					"value2": 4

--- a/cards/src/main/resources/cards/the_old_gods/mage/minion_cult_sorcerer.json
+++ b/cards/src/main/resources/cards/the_old_gods/mage/minion_cult_sorcerer.json
@@ -36,13 +36,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 1
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 1
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_beckoner_of_evil.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_beckoner_of_evil.json
@@ -32,13 +32,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 2
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 2
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_crazed_worshipper.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_crazed_worshipper.json
@@ -36,13 +36,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 1
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 1
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_cthun.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_cthun.json
@@ -32,12 +32,12 @@
 					"target": "SELF",
 					"attackBonus": {
 						"class": "AttributeValueProvider",
-						"target": "FRIENDLY_HERO",
+						"target": "FRIENDLY_PLAYER",
 						"attribute": "CTHUN_ATTACK_BUFF"
 					},
 					"hpBonus": {
 						"class": "AttributeValueProvider",
-						"target": "FRIENDLY_HERO",
+						"target": "FRIENDLY_PLAYER",
 						"attribute": "CTHUN_HEALTH_BUFF"
 					}
 				},
@@ -50,7 +50,7 @@
 					},
 					"condition": {
 						"class": "AttributeCondition",
-						"target": "FRIENDLY_HERO",
+						"target": "FRIENDLY_PLAYER",
 						"attribute": "CTHUN_TAUNT"
 					}
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_cthuns_chosen.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_cthuns_chosen.json
@@ -32,13 +32,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 2
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 2
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_disciple_of_cthun.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_disciple_of_cthun.json
@@ -37,13 +37,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 2
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 2
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_doomcaller.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_doomcaller.json
@@ -32,13 +32,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 2
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 2
 				},

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_nerubian_prophet.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_nerubian_prophet.json
@@ -15,7 +15,7 @@
 		},
 		"spell": {
 			"class": "CardCostModifierSpell",
-			"target": "FRIENDLY_HERO",
+			"target": "FRIENDLY_PLAYER",
 			"cardCostModifier": {
 				"class": "CardCostModifier",
 				"target": "SELF",

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_skeram_cultist.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_skeram_cultist.json
@@ -32,13 +32,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 2
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 2
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_twilight_elder.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_twilight_elder.json
@@ -36,13 +36,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 1
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 1
 				}

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_twilight_geomancer.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_twilight_geomancer.json
@@ -32,7 +32,7 @@
 				},
 				{
 					"class": "AddAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_TAUNT"
 				}
 			]

--- a/cards/src/main/resources/cards/the_old_gods/neutral/minion_twin_emperor_veklor.json
+++ b/cards/src/main/resources/cards/the_old_gods/neutral/minion_twin_emperor_veklor.json
@@ -49,7 +49,7 @@
 					"operation": "GREATER_OR_EQUAL",
 					"value1": {
 						"class": "AttributeValueProvider",
-						"target": "FRIENDLY_HERO",
+						"target": "FRIENDLY_PLAYER",
 						"attribute": "CTHUN_ATTACK_BUFF"
 					},
 					"value2": 4

--- a/cards/src/main/resources/cards/the_old_gods/priest/minion_hooded_acolyte.json
+++ b/cards/src/main/resources/cards/the_old_gods/priest/minion_hooded_acolyte.json
@@ -35,13 +35,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 1
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 1
 				}

--- a/cards/src/main/resources/cards/the_old_gods/priest/minion_twilight_darkmender.json
+++ b/cards/src/main/resources/cards/the_old_gods/priest/minion_twilight_darkmender.json
@@ -50,7 +50,7 @@
 					"operation": "GREATER_OR_EQUAL",
 					"value1": {
 						"class": "AttributeValueProvider",
-						"target": "FRIENDLY_HERO",
+						"target": "FRIENDLY_PLAYER",
 						"attribute": "CTHUN_ATTACK_BUFF"
 					},
 					"value2": 4

--- a/cards/src/main/resources/cards/the_old_gods/rogue/minion_blade_of_cthun.json
+++ b/cards/src/main/resources/cards/the_old_gods/rogue/minion_blade_of_cthun.json
@@ -54,7 +54,7 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": {
 						"class": "AttributeValueProvider",
@@ -64,7 +64,7 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": {
 						"class": "AttributeValueProvider",

--- a/cards/src/main/resources/cards/the_old_gods/warlock/minion_usher_of_souls.json
+++ b/cards/src/main/resources/cards/the_old_gods/warlock/minion_usher_of_souls.json
@@ -36,13 +36,13 @@
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_ATTACK_BUFF",
 					"value": 1
 				},
 				{
 					"class": "ModifyAttributeSpell",
-					"target": "FRIENDLY_HERO",
+					"target": "FRIENDLY_PLAYER",
 					"attribute": "CTHUN_HEALTH_BUFF",
 					"value": 1
 				}

--- a/cards/src/main/resources/cards/the_old_gods/warrior/minion_ancient_shieldbearer.json
+++ b/cards/src/main/resources/cards/the_old_gods/warrior/minion_ancient_shieldbearer.json
@@ -50,7 +50,7 @@
 					"operation": "GREATER_OR_EQUAL",
 					"value1": {
 						"class": "AttributeValueProvider",
-						"target": "FRIENDLY_HERO",
+						"target": "FRIENDLY_PLAYER",
 						"attribute": "CTHUN_ATTACK_BUFF"
 					},
 					"value2": 4

--- a/game/src/main/java/net/demilich/metastone/game/Player.java
+++ b/game/src/main/java/net/demilich/metastone/game/Player.java
@@ -10,15 +10,14 @@ import net.demilich.metastone.game.cards.CardCollection;
 import net.demilich.metastone.game.decks.Deck;
 import net.demilich.metastone.game.entities.Actor;
 import net.demilich.metastone.game.entities.Entity;
+import net.demilich.metastone.game.entities.EntityType;
 import net.demilich.metastone.game.entities.heroes.Hero;
 import net.demilich.metastone.game.entities.minions.Minion;
-import net.demilich.metastone.game.logic.CustomCloneable;
 import net.demilich.metastone.game.statistics.GameStatistics;
 import net.demilich.metastone.game.gameconfig.PlayerConfig;
 
-public class Player extends CustomCloneable {
+public class Player extends Entity {
 
-	private final String name;
 	private Hero hero;
 	private final String deckName;
 
@@ -31,8 +30,6 @@ public class Player extends CustomCloneable {
 
 	private final GameStatistics statistics = new GameStatistics();
 
-	private int id = -1;
-
 	private int mana;
 	private int maxMana;
 	private int lockedMana;
@@ -42,7 +39,7 @@ public class Player extends CustomCloneable {
 	private IBehaviour behaviour;
 
 	private Player(Player otherPlayer) {
-		this.name = otherPlayer.name;
+		this.setName(otherPlayer.getName());
 		this.deckName = otherPlayer.getDeckName();
 		this.setHero(otherPlayer.getHero().clone());
 		this.deck = otherPlayer.getDeck().clone();
@@ -53,7 +50,7 @@ public class Player extends CustomCloneable {
 		this.graveyard.addAll(otherPlayer.graveyard);
 		this.setAsideZone.addAll(otherPlayer.setAsideZone);
 		this.secrets.addAll(otherPlayer.secrets);
-		this.id = otherPlayer.id;
+		this.setId(otherPlayer.getId());
 		this.mana = otherPlayer.mana;
 		this.maxMana = otherPlayer.maxMana;
 		this.lockedMana = otherPlayer.lockedMana;
@@ -64,9 +61,9 @@ public class Player extends CustomCloneable {
 	public Player(PlayerConfig config) {
 		config.build();
 		Deck selectedDeck = config.getDeckForPlay();
-		this.name = config.getName();
 		this.deck = selectedDeck.getCardsCopy();
 		this.setHero(config.getHeroForPlay().createHero());
+		this.setName(config.getName() + " - " + hero.getName());
 		this.deckName = selectedDeck.getName();
 		setBehaviour(config.getBehaviour().clone());
 		setHideCards(config.hideCards());
@@ -96,6 +93,11 @@ public class Player extends CustomCloneable {
 		return deckName;
 	}
 
+	@Override
+	public EntityType getEntityType() {
+		return EntityType.PLAYER;
+	}
+
 	public List<Entity> getGraveyard() {
 		return graveyard;
 	}
@@ -106,10 +108,6 @@ public class Player extends CustomCloneable {
 
 	public Hero getHero() {
 		return hero;
-	}
-
-	public int getId() {
-		return id;
 	}
 
 	public int getLockedMana() {
@@ -126,10 +124,6 @@ public class Player extends CustomCloneable {
 
 	public List<Minion> getMinions() {
 		return minions;
-	}
-
-	public String getName() {
-		return "'" + name + "' (" + getHero().getName() + ")";
 	}
 
 	public HashSet<String> getSecrets() {
@@ -158,10 +152,6 @@ public class Player extends CustomCloneable {
 
 	public void setHideCards(boolean hideCards) {
 		this.hideCards = hideCards;
-	}
-
-	public void setId(int id) {
-		this.id = id;
 	}
 
 	public void setLockedMana(int lockedMana) {

--- a/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
@@ -209,6 +209,10 @@ public class ParseUtils {
 			return EntityReference.FRIENDLY_HAND;
 		case "enemy_hand":
 			return EntityReference.ENEMY_HAND;
+		case "friendly_player":
+			return EntityReference.FRIENDLY_PLAYER;
+		case "enemy_player":
+			return EntityReference.ENEMY_PLAYER;
 		default:
 			return null;
 		}

--- a/game/src/main/java/net/demilich/metastone/game/entities/Entity.java
+++ b/game/src/main/java/net/demilich/metastone/game/entities/Entity.java
@@ -15,6 +15,12 @@ public abstract class Entity extends CustomCloneable {
 	private int id = IdFactory.UNASSIGNED;
 	private int ownerIndex = -1;
 
+	@Override
+	public Entity clone() {
+		Entity clone = (Entity) super.clone();
+		return clone;
+	}
+
 	public Object getAttribute(Attribute attribute) {
 		return attributes.get(attribute);
 	}

--- a/game/src/main/java/net/demilich/metastone/game/entities/EntityType.java
+++ b/game/src/main/java/net/demilich/metastone/game/entities/EntityType.java
@@ -6,4 +6,5 @@ public enum EntityType {
 	MINION,
 	WEAPON,
 	CARD,
+	PLAYER,
 }

--- a/game/src/main/java/net/demilich/metastone/game/entities/heroes/Hero.java
+++ b/game/src/main/java/net/demilich/metastone/game/entities/heroes/Hero.java
@@ -56,9 +56,6 @@ public class Hero extends Actor {
 	public Map<Attribute, Object> getAttributesCopy() {
 		Map<Attribute, Object> copy = new EnumMap<>(Attribute.class);
 		for (Attribute attribute : attributes.keySet()) {
-			if (attribute != Attribute.COMBO) {
-				continue;
-			}
 			copy.put(attribute, attributes.get(attribute));
 		}
 		return copy;

--- a/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/GameLogic.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -145,7 +144,7 @@ public class GameLogic implements Cloneable {
 	public void afterCardPlayed(int playerId, CardReference cardReference) {
 		Player player = context.getPlayer(playerId);
 
-		player.getHero().modifyAttribute(Attribute.COMBO, +1);
+		player.modifyAttribute(Attribute.COMBO, +1);
 		Card card = context.resolveCardReference(cardReference);
 
 		if (card.getCardType().isCardType(CardType.SPELL) && !card.hasAttribute(Attribute.COUNTERED)) {
@@ -300,11 +299,6 @@ public class GameLogic implements Cloneable {
 		hero.setId(player.getHero().getId());
 		if (hero.getHeroClass() == null || hero.getHeroClass() == HeroClass.ANY) {
 			hero.setHeroClass(player.getHero().getHeroClass());
-		}
-
-		Map<Attribute, Object> attributesToCopy = player.getHero().getAttributesCopy();
-		for (Map.Entry<Attribute, Object> entry : attributesToCopy.entrySet()) {
-			hero.setAttribute(entry.getKey(), entry.getValue());
 		}
 
 		log("{}'s hero has been changed to {}", player.getName(), hero);
@@ -532,9 +526,9 @@ public class GameLogic implements Cloneable {
 		CardCollection deck = player.getDeck();
 		if (deck.isEmpty()) {
 			Hero hero = player.getHero();
-			int fatigue = hero.hasAttribute(Attribute.FATIGUE) ? hero.getAttributeValue(Attribute.FATIGUE) : 0;
+			int fatigue = player.hasAttribute(Attribute.FATIGUE) ? player.getAttributeValue(Attribute.FATIGUE) : 0;
 			fatigue++;
-			hero.setAttribute(Attribute.FATIGUE, fatigue);
+			player.setAttribute(Attribute.FATIGUE, fatigue);
 			damage(player, hero, fatigue, hero);
 			log("{}'s deck is empty, taking {} fatigue damage!", player.getName(), fatigue);
 			player.getStatistics().fatigueDamage(fatigue);
@@ -572,7 +566,7 @@ public class GameLogic implements Cloneable {
 			minion.removeAttribute(Attribute.TEMPORARY_ATTACK_BONUS);
 			handleFrozen(minion);
 		}
-		hero.removeAttribute(Attribute.COMBO);
+		player.removeAttribute(Attribute.COMBO);
 		hero.activateWeapon(false);
 		log("{} ends his turn.", player.getName());
 		context.fireGameEvent(new TurnEndEvent(context, playerId));
@@ -1244,7 +1238,7 @@ public class GameLogic implements Cloneable {
 		}
 
 		if (card.hasAttribute(Attribute.OVERLOAD)) {
-			player.getHero().modifyAttribute(Attribute.OVERLOAD, card.getAttributeValue(Attribute.OVERLOAD));
+			player.modifyAttribute(Attribute.OVERLOAD, card.getAttributeValue(Attribute.OVERLOAD));
 		}
 	}
 
@@ -1581,7 +1575,7 @@ public class GameLogic implements Cloneable {
 		}
 		player.getStatistics().startTurn();
 
-		player.setLockedMana(player.getHero().getAttributeValue(Attribute.OVERLOAD));
+		player.setLockedMana(player.getAttributeValue(Attribute.OVERLOAD));
 		int mana = Math.min(player.getMaxMana() - player.getLockedMana(), MAX_MANA);
 		player.setMana(mana);
 		String manaString = player.getMana() + "/" + player.getMaxMana();
@@ -1590,7 +1584,7 @@ public class GameLogic implements Cloneable {
 		}
 		log("{} starts his turn with {} mana", player.getName(), manaString);
 
-		player.getHero().removeAttribute(Attribute.OVERLOAD);
+		player.removeAttribute(Attribute.OVERLOAD);
 		for (Minion minion : player.getMinions()) {
 			minion.removeAttribute(Attribute.TEMPORARY_ATTACK_BONUS);
 		}

--- a/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
@@ -75,6 +75,9 @@ public class TargetLogic {
 			return environmentResult;
 		}
 		for (Player player : context.getPlayers()) {
+			if (player.getId() == targetId) {
+				return player;
+			}
 			if (player.getHero().getId() == targetId) {
 				return player.getHero();
 			} else if (player.getHero().getWeapon() != null && player.getHero().getWeapon().getId() == targetId) {
@@ -269,6 +272,10 @@ public class TargetLogic {
 			return new ArrayList<>(player.getHand().toList());
 		} else if (targetKey == EntityReference.ENEMY_HAND) {
 			return new ArrayList<>(context.getOpponent(player).getHand().toList());
+		} else if (targetKey == EntityReference.FRIENDLY_PLAYER) {
+			return singleTargetAsList(player);
+		} else if (targetKey == EntityReference.ENEMY_PLAYER) {
+			return singleTargetAsList(context.getOpponent(player));
 		}
 
 		return singleTargetAsList(findEntity(context, targetKey));

--- a/game/src/main/java/net/demilich/metastone/game/spells/AddSecretSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/AddSecretSpell.java
@@ -15,7 +15,7 @@ public class AddSecretSpell extends Spell {
 	public static SpellDesc create(Secret secret) {
 		Map<SpellArg, Object> arguments = SpellDesc.build(AddSecretSpell.class);
 		arguments.put(SpellArg.SECRET, secret);
-		arguments.put(SpellArg.TARGET, EntityReference.FRIENDLY_HERO);
+		arguments.put(SpellArg.TARGET, EntityReference.FRIENDLY_PLAYER);
 		return new SpellDesc(arguments);
 	}
 

--- a/game/src/main/java/net/demilich/metastone/game/spells/ClearOverloadSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/ClearOverloadSpell.java
@@ -24,7 +24,7 @@ public class ClearOverloadSpell extends Spell {
 			player.setLockedMana(0);
 		}
 
-		player.getHero().removeAttribute(Attribute.OVERLOAD);
+		player.removeAttribute(Attribute.OVERLOAD);
 	}
 
 }

--- a/game/src/main/java/net/demilich/metastone/game/spells/ComboSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/ComboSpell.java
@@ -21,7 +21,7 @@ public class ComboSpell extends ConditionalEffectSpell {
 
 	@Override
 	protected boolean isConditionFulfilled(GameContext context, Player player, SpellDesc desc, Entity target) {
-		return player.getHero().hasAttribute(Attribute.COMBO);
+		return player.hasAttribute(Attribute.COMBO);
 	}
 
 }

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/condition/ComboCondition.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/condition/ComboCondition.java
@@ -13,7 +13,7 @@ public class ComboCondition extends Condition {
 
 	@Override
 	protected boolean isFulfilled(GameContext context, Player player, ConditionDesc desc, Entity target) {
-		return player.getHero().hasAttribute(Attribute.COMBO);
+		return player.hasAttribute(Attribute.COMBO);
 	}
 
 }

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/valueprovider/AttributeValueProvider.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/valueprovider/AttributeValueProvider.java
@@ -38,13 +38,17 @@ public class AttributeValueProvider extends ValueProvider {
 				Card card = (Card) entity;
 				value += card.getAttributeValue(attribute);
 			} else {
-				Actor source = (Actor) entity;
-				if (attribute == Attribute.ATTACK) {
-					value += source.getAttack();
-				} else if (attribute == Attribute.MAX_HP) {
-					value += source.getMaxHp();
+				if (entity instanceof Actor) {
+					Actor source = (Actor) entity;
+					if (attribute == Attribute.ATTACK) {
+						value += source.getAttack();
+					} else if (attribute == Attribute.MAX_HP) {
+						value += source.getMaxHp();
+					} else {
+						value += source.getAttributeValue(attribute);
+					}
 				} else {
-					value += source.getAttributeValue(attribute);
+					value += entity.getAttributeValue(attribute);
 				}
 			}
 		}

--- a/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
+++ b/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
@@ -20,7 +20,9 @@ public class EntityReference {
 	public static final EntityReference ENEMY_WEAPON = new EntityReference(-15);
 	public static final EntityReference FRIENDLY_HAND = new EntityReference(-16);
 	public static final EntityReference ENEMY_HAND = new EntityReference(-17);
-	
+
+	public static final EntityReference FRIENDLY_PLAYER = new EntityReference(-21);
+	public static final EntityReference ENEMY_PLAYER = new EntityReference(-22);
 
 	public static final EntityReference TARGET = new EntityReference(-30);
 	public static final EntityReference SPELL_TARGET = new EntityReference(-31);

--- a/game/src/main/java/net/demilich/metastone/game/targeting/IdFactory.java
+++ b/game/src/main/java/net/demilich/metastone/game/targeting/IdFactory.java
@@ -1,14 +1,18 @@
 package net.demilich.metastone.game.targeting;
 
+import net.demilich.metastone.game.GameContext;
 import net.demilich.metastone.game.logic.CustomCloneable;
 
 public class IdFactory extends CustomCloneable {
 
 	public static final int UNASSIGNED = -1;
+	public static final int PLAYER_1 = GameContext.PLAYER_1;
+	public static final int PLAYER_2 = GameContext.PLAYER_2;
 
 	private int id;
 
 	public IdFactory() {
+		id = PLAYER_2 + 1;
 	}
 
 	private IdFactory(int resumeId) {


### PR DESCRIPTION
- Created Player Entity
 - Moved spell triggers and card cost modifiers to target the Player Entity instead. Technically, there wasn't any issues with this, in part because of how Heroes currently change, but that may need to be changed eventually, especially since Preparation is now fixed to be a Player aura instead.
 - Moved certain Attributes to target the Player instead of the Hero in cases where the Attribute needs to be retained on Hero change (Fatigue, Combo, Overload, C'Thun buffs)
 - Fixed most Hero change bugs. (Little known bug: Playing Jaraxxus reset your Fatigue and Overload to 0.)
- Added FRIENDLY_PLAYER and ENEMY_PLAYER Entity References. These will typically be unneeded, but they can be helpful for permanent buffs.
- Fixed a typo in Wily Runt. What a rascal.
- Fixes #186 