### PR TITLE
More Feature Updates

### DIFF
--- a/game/src/main/java/net/demilich/metastone/game/GameContext.java
+++ b/game/src/main/java/net/demilich/metastone/game/GameContext.java
@@ -245,6 +245,20 @@ public class GameContext implements Cloneable, IDisposable {
 		return (Stack<EntityReference>) environment.get(Environment.EVENT_TARGET_REFERENCE_STACK);
 	}
 
+	public List<Actor> getLeftMinions(Player player, EntityReference minionReference) {
+		List<Actor> leftMinions = new ArrayList<>();
+		Actor minion = (Actor) resolveSingleTarget(minionReference);
+		List<Minion> minions = getPlayer(minion.getOwner()).getMinions();
+		int index = minions.indexOf(minion);
+		if (index == -1) {
+			return null;
+		}
+		for (int i = 0; i < index; i++) {
+			leftMinions.add(minions.get(i));
+		}
+		return leftMinions;
+	}
+
 	public GameLogic getLogic() {
 		return logic;
 	}
@@ -305,6 +319,20 @@ public class GameContext implements Cloneable, IDisposable {
 
 	public Player[] getPlayers() {
 		return players;
+	}
+
+	public List<Actor> getRightMinions(Player player, EntityReference minionReference) {
+		List<Actor> rightMinions = new ArrayList<>();
+		Actor minion = (Actor) resolveSingleTarget(minionReference);
+		List<Minion> minions = getPlayer(minion.getOwner()).getMinions();
+		int index = minions.indexOf(minion);
+		if (index == -1) {
+			return null;
+		}
+		for (int i = index + 1; i < player.getMinions().size(); i++) {
+			rightMinions.add(minions.get(i));
+		}
+		return rightMinions;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/desc/ParseUtils.java
@@ -219,6 +219,10 @@ public class ParseUtils {
 			return EntityReference.FRIENDLY_PLAYER;
 		case "enemy_player":
 			return EntityReference.ENEMY_PLAYER;
+		case "minions_to_left":
+			return EntityReference.MINIONS_TO_LEFT;
+		case "minions_to_right":
+			return EntityReference.MINIONS_TO_RIGHT;
 		default:
 			return null;
 		}

--- a/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
+++ b/game/src/main/java/net/demilich/metastone/game/logic/TargetLogic.java
@@ -239,6 +239,12 @@ public class TargetLogic {
 			return targets;
 		} else if (targetKey == EntityReference.ADJACENT_MINIONS) {
 			return new ArrayList<>(context.getAdjacentMinions(player, source.getReference()));
+		} else if (targetKey == EntityReference.OPPOSITE_MINIONS) {
+			return new ArrayList<>(context.getOppositeMinions(player, source.getReference()));
+		} else if (targetKey == EntityReference.MINIONS_TO_LEFT) {
+			return new ArrayList<>(context.getLeftMinions(player, source.getReference()));
+		} else if (targetKey == EntityReference.MINIONS_TO_RIGHT) {
+			return new ArrayList<>(context.getRightMinions(player, source.getReference()));
 		} else if (targetKey == EntityReference.SELF) {
 			return singleTargetAsList(source);
 		} else if (targetKey == EntityReference.EVENT_TARGET) {

--- a/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
+++ b/game/src/main/java/net/demilich/metastone/game/targeting/EntityReference.java
@@ -25,6 +25,8 @@ public class EntityReference {
 	public static final EntityReference LEFTMOST_ENEMY_MINION = new EntityReference(-20);
 	public static final EntityReference FRIENDLY_PLAYER = new EntityReference(-21);
 	public static final EntityReference ENEMY_PLAYER = new EntityReference(-22);
+	public static final EntityReference MINIONS_TO_LEFT = new EntityReference(-23);
+	public static final EntityReference MINIONS_TO_RIGHT = new EntityReference(-24);
 
 	public static final EntityReference TARGET = new EntityReference(-30);
 	public static final EntityReference SPELL_TARGET = new EntityReference(-31);

--- a/game/src/main/java/net/demilich/metastone/game/targeting/TargetSelection.java
+++ b/game/src/main/java/net/demilich/metastone/game/targeting/TargetSelection.java
@@ -10,7 +10,6 @@ public enum TargetSelection {
 	FRIENDLY_HERO,
 	MINIONS,
 	HEROES,
-	ADJACENT_MINIONS,
 	AUTO,
 	ANY
 }


### PR DESCRIPTION
- Added MINIONS_TO_LEFT and MINIONS_TO_RIGHT targeting for auras and spells, which target every minion to the left and right, respectively.
- Removed ADJACENT_MINIONS target selection, as it wasn't being used nor could it be implemented as it was. (There might be a way to do so with filtering in the future? Otherwise, it requires a bit of a rewrite, but as it doesn't exist now, I'm removing it.)