### PR TITLE
Fixed Prince Malchezaar

### DIFF
--- a/cards/src/main/resources/cards/basic/mage/token_mirror_image.json
+++ b/cards/src/main/resources/cards/basic/mage/token_mirror_image.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 0,
 	"baseHp": 2,
-	"heroClass": "ANY",
+	"heroClass": "MAGE",
 	"rarity": "FREE",
 	"description": "Taunt",
 	"attributes": {

--- a/cards/src/main/resources/cards/classic/mage/token_spellbender.json
+++ b/cards/src/main/resources/cards/classic/mage/token_spellbender.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 1,
 	"baseHp": 3,
-	"heroClass": "ANY",
+	"heroClass": "MAGE",
 	"rarity": "EPIC",
 	"collectible": false,
 	"set": "CLASSIC",

--- a/cards/src/main/resources/cards/classic/shaman/token_spirit_wolf.json
+++ b/cards/src/main/resources/cards/classic/shaman/token_spirit_wolf.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 2,
 	"baseHp": 3,
-	"heroClass": "ANY",
+	"heroClass": "SHAMAN",
 	"rarity": "RARE",
 	"description": "",
 	"attributes": {

--- a/cards/src/main/resources/cards/classic/warlock/token_infernal.json
+++ b/cards/src/main/resources/cards/classic/warlock/token_infernal.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 6,
 	"baseHp": 6,
-	"heroClass": "ANY",
+	"heroClass": "WARLOCK",
 	"rarity": "COMMON",
 	"race": "DEMON",
 	"description": "",

--- a/cards/src/main/resources/cards/classic/warlock/token_worthless_imp.json
+++ b/cards/src/main/resources/cards/classic/warlock/token_worthless_imp.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 1,
 	"baseHp": 1,
-	"heroClass": "ANY",
+	"heroClass": "WARLOCK",
 	"rarity": "COMMON",
 	"race": "DEMON",
 	"description": "You are out of demons! At least there are always imps...",

--- a/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/spell_burrowing_mine.json
+++ b/cards/src/main/resources/cards/goblins_vs_gnomes/warrior/spell_burrowing_mine.json
@@ -3,7 +3,7 @@
 	"name": "Burrowing Mine",
 	"baseManaCost": 0,
 	"type": "SPELL",
-	"heroClass": "ANY",
+	"heroClass": "WARRIOR",
 	"rarity": "FREE",
 	"description": "When you draw this, it explodes. You take 10 damage and draw a card.",
 	"targetSelection": "NONE",

--- a/cards/src/main/resources/cards/league_of_explorers/token_scarab.json
+++ b/cards/src/main/resources/cards/league_of_explorers/token_scarab.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 1,
 	"baseHp": 1,
-	"heroClass": "ANY",
+	"heroClass": "WARRIOR",
 	"rarity": "FREE",
 	"race": "BEAST",
 	"description": "Taunt",

--- a/cards/src/main/resources/cards/one_night_in_karazhan/minion_prince_malchezaar.json
+++ b/cards/src/main/resources/cards/one_night_in_karazhan/minion_prince_malchezaar.json
@@ -20,9 +20,39 @@
 			"spell": {
 				"class": "ShuffleToDeckSpell",
 				"cardFilter": {
-					"class": "CardFilter",	
-					"cardType": "MINION",
-					"rarity": "LEGENDARY"
+					"class": "AndFilter",
+					"filters": [
+						{
+							"class": "CardFilter",	
+							"cardType": "MINION",
+							"rarity": "LEGENDARY"
+						},
+						{
+							"class": "OrFilter",
+							"invert": true,
+							"filters": [
+								{
+									"class": "InDeckFilter"
+								},
+								{
+									"class": "InHandFilter"
+								}
+							]
+						},
+						{
+							"class": "OrFilter",
+							"filters": [
+								{
+									"class": "CardFilter",
+									"heroClass": "ANY"
+								},
+								{
+									"class": "CardFilter",
+									"heroClass": "SELF"
+								}
+							]
+						}
+					]
 				}
 			}
 		}

--- a/cards/src/main/resources/cards/one_night_in_karazhan/token_pawn.json
+++ b/cards/src/main/resources/cards/one_night_in_karazhan/token_pawn.json
@@ -5,7 +5,7 @@
 	"type": "MINION",
 	"baseAttack": 1,
 	"baseHp": 1,
-	"heroClass": "ANY",
+	"heroClass": "WARRIOR",
 	"rarity": "RARE",
 	"description": "Taunt",
 	"attributes": {

--- a/cards/src/main/resources/cards/the_old_gods/rogue/spell_fadeleaf_toxin.json
+++ b/cards/src/main/resources/cards/the_old_gods/rogue/spell_fadeleaf_toxin.json
@@ -3,7 +3,7 @@
 	"name": "Fadeleaf Toxin",
 	"baseManaCost": 1,
 	"type": "SPELL",
-	"heroClass": "ANY",
+	"heroClass": "ROGUE",
 	"rarity": "FREE",
 	"description": "Give a friendly minion Stealth until your next turn.",
 	"targetSelection": "FRIENDLY_MINIONS",

--- a/game/src/main/java/net/demilich/metastone/game/spells/ShuffleToDeckSpell.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/ShuffleToDeckSpell.java
@@ -35,7 +35,9 @@ public class ShuffleToDeckSpell extends Spell {
 
 		int howMany = desc.getValue(SpellArg.HOW_MANY, context, player, target, source, 1);
 		for (int i = 0; i < howMany; i++) {
-			context.getLogic().shuffleToDeck(player, card.clone());
+			if (card != null) {
+				context.getLogic().shuffleToDeck(player, card.clone());
+			}
 		}
 	}
 

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/filter/CardFilter.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/filter/CardFilter.java
@@ -65,7 +65,7 @@ public class CardFilter extends EntityFilter {
 		}
 		
 		HeroClass heroClass = (HeroClass) desc.get(FilterArg.HERO_CLASS);
-		if (heroClass != null && heroClass != HeroClass.ANY && !heroClassTest(context, player, card, heroClass)) {
+		if (heroClass != null && !heroClassTest(context, player, card, heroClass)) {
 			return false;
 		}
 		

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/filter/InHandFilter.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/filter/InHandFilter.java
@@ -1,0 +1,30 @@
+package net.demilich.metastone.game.spells.desc.filter;
+
+import net.demilich.metastone.game.GameContext;
+import net.demilich.metastone.game.Player;
+import net.demilich.metastone.game.cards.Card;
+import net.demilich.metastone.game.entities.Actor;
+import net.demilich.metastone.game.entities.Entity;
+
+public class InHandFilter extends EntityFilter {
+
+	public InHandFilter(FilterDesc desc) {
+		super(desc);
+	}
+	
+	@Override
+	protected boolean test(GameContext context, Player player, Entity entity) {
+		Card card = null;
+		if (entity instanceof Card) {
+			card = (Card) entity;
+		} else if (entity instanceof Actor) {
+			Actor actor = (Actor) entity;
+			card = actor.getSourceCard();
+		} else {
+			return false;
+		}
+
+		return player.getHand().containsCard(card);
+	}
+
+}

--- a/game/src/main/java/net/demilich/metastone/game/spells/desc/filter/OrFilter.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/desc/filter/OrFilter.java
@@ -4,9 +4,9 @@ import net.demilich.metastone.game.GameContext;
 import net.demilich.metastone.game.Player;
 import net.demilich.metastone.game.entities.Entity;
 
-public class AndFilter extends EntityFilter {
+public class OrFilter extends EntityFilter {
 
-	public AndFilter(FilterDesc desc) {
+	public OrFilter(FilterDesc desc) {
 		super(desc);
 	}
 
@@ -14,11 +14,11 @@ public class AndFilter extends EntityFilter {
 	protected boolean test(GameContext context, Player player, Entity entity) {
 		EntityFilter[] filters = (EntityFilter[]) desc.get(FilterArg.FILTERS);
 		for (EntityFilter filter : filters) {
-			if (!filter.matches(context, player, entity)) {
-				return false;
+			if (filter.matches(context, player, entity)) {
+				return true;
 			}
 		}
-		return true;
+		return false;
 	}
 
 }


### PR DESCRIPTION
- Prince Malchezaar has finally taken it upon himself to make sure those Legendary minions that didn't get an invite (but were clearly allowed to be invited) can make an appearance in your deck. This means that if he's invited to your Warrior deck, he won't try to invite Archmage Antonidas, because that's a major faux pas. But you better believe Majordomo Executus gets an invite to every party. That guy is always fashionably early.
- Fixed a few bugs that were occurring with the AndFilter.
- Added some new filters (OrFilter, InHandFilter)
- Allowed the used of neutral cards with the CardFilter.
- Fixed some tokens with the wrong hero class.