### PR TITLE
Card Fixes

### DIFF
--- a/cards/src/main/resources/cards/one_night_in_karazhan/weapon_spirit_claws.json
+++ b/cards/src/main/resources/cards/one_night_in_karazhan/weapon_spirit_claws.json
@@ -1,7 +1,7 @@
 {
 	"id": "weapon_spirit_claws",
 	"name": "Spirit Claws",
-	"baseManaCost": 3,
+	"baseManaCost": 1,
 	"type": "WEAPON",
 	"damage": 1,
 	"durability": 3,

--- a/cards/src/main/resources/cards/the_old_gods/warrior/minion_nzoths_first_mate.json
+++ b/cards/src/main/resources/cards/the_old_gods/warrior/minion_nzoths_first_mate.json
@@ -7,6 +7,7 @@
 	"baseHp": 1,
 	"heroClass": "WARRIOR",
 	"rarity": "COMMON",
+	"race": "PIRATE",
 	"description": "Battlecry: Equip a 1/3 Rusty Hook.",
 	"battlecry": {
 		"spell": {


### PR DESCRIPTION
- Spirit Claws now costs 1. (Fixes #256)
- N'Zoth's first mate is adamant about being a pirate.