### PR TITLE
Added Deck Formats to Deck Builder

### DIFF
--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/CardFilter.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/CardFilter.java
@@ -1,15 +1,22 @@
 package net.demilich.metastone.gui.deckbuilder;
 
 import net.demilich.metastone.game.cards.CardSet;
+import net.demilich.metastone.game.decks.DeckFormat;
 
 public class CardFilter {
 
 	private final String text;
 	private final CardSet set;
+	private final DeckFormat format;
 
-	public CardFilter(String text, CardSet set) {
+	public CardFilter(String text, CardSet set, DeckFormat format) {
 		this.text = text;
 		this.set = set;
+		this.format = format;
+	}
+
+	public DeckFormat getFormat() {
+		return format;
 	}
 
 	public CardSet getSet() {

--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckBuilderMediator.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckBuilderMediator.java
@@ -8,6 +8,7 @@ import net.demilich.nittygrittymvc.interfaces.INotification;
 import net.demilich.metastone.GameNotification;
 import net.demilich.metastone.game.cards.Card;
 import net.demilich.metastone.game.decks.Deck;
+import net.demilich.metastone.game.decks.DeckFormat;
 import net.demilich.metastone.game.decks.validation.DefaultDeckValidator;
 import net.demilich.metastone.gui.dialog.DialogNotification;
 import net.demilich.metastone.gui.dialog.DialogType;
@@ -49,6 +50,10 @@ public class DeckBuilderMediator extends Mediator<GameNotification> {
 					DialogType.WARNING);
 			getFacade().notifyObservers(dialogNotification);
 			break;
+		case DECK_FORMATS_LOADED:
+			List<DeckFormat> deckFormats = (List<DeckFormat>) notification.getBody();
+			view.injectDeckFormats(deckFormats);
+			break;
 		case DUPLICATE_DECK_NAME:
 			getFacade().notifyObservers(new DialogNotification("Duplicate deck name",
 					"This deck name was already used for another deck. Please choose another name", DialogType.WARNING));
@@ -76,6 +81,7 @@ public class DeckBuilderMediator extends Mediator<GameNotification> {
 	public void onRegister() {
 		getFacade().sendNotification(GameNotification.SHOW_VIEW, view);
 		getFacade().sendNotification(GameNotification.LOAD_DECKS);
+		getFacade().sendNotification(GameNotification.LOAD_DECK_FORMATS);
 	}
 
 }

--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckBuilderView.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/DeckBuilderView.java
@@ -15,11 +15,13 @@ import net.demilich.metastone.GameNotification;
 import net.demilich.metastone.NotificationProxy;
 import net.demilich.metastone.game.cards.Card;
 import net.demilich.metastone.game.decks.Deck;
+import net.demilich.metastone.game.decks.DeckFormat;
 import net.demilich.metastone.game.decks.MetaDeck;
 import net.demilich.metastone.gui.deckbuilder.metadeck.MetaDeckListView;
 import net.demilich.metastone.gui.deckbuilder.metadeck.MetaDeckView;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class DeckBuilderView extends BorderPane implements EventHandler<ActionEvent> {
@@ -49,6 +51,8 @@ public class DeckBuilderView extends BorderPane implements EventHandler<ActionEv
 	private final DeckNameView deckNameView;
 	private final MetaDeckView metaDeckView;
 	private final MetaDeckListView metaDeckListView;
+
+	private List<DeckFormat> deckFormats = new ArrayList<DeckFormat>();
 
 	public DeckBuilderView() {
 		FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("/fxml/DeckBuilderView.fxml"));
@@ -107,7 +111,7 @@ public class DeckBuilderView extends BorderPane implements EventHandler<ActionEv
 		} else {
 			showMainArea(cardView);
 			showSidebar(cardListView);
-			showBottomBar(new CardFilterView());
+			showBottomBar(new CardFilterView(deckFormats));
 		}
 		showLowerInfoArea(deckInfoView);
 		showUpperInfoArea(deckNameView);
@@ -125,6 +129,10 @@ public class DeckBuilderView extends BorderPane implements EventHandler<ActionEv
 		} else if (event.getSource() == backButton) {
 			NotificationProxy.sendNotification(GameNotification.MAIN_MENU);
 		}
+	}
+
+	public void injectDeckFormats(List<DeckFormat> deckFormats) {
+		this.deckFormats.addAll(deckFormats);
 	}
 
 	private void showBottomBar(Node content) {

--- a/app/src/main/java/net/demilich/metastone/gui/deckbuilder/FilterCardsCommand.java
+++ b/app/src/main/java/net/demilich/metastone/gui/deckbuilder/FilterCardsCommand.java
@@ -9,8 +9,18 @@ import net.demilich.nittygrittymvc.interfaces.INotification;
 import net.demilich.metastone.GameNotification;
 import net.demilich.metastone.game.cards.Card;
 import net.demilich.metastone.game.cards.CardSet;
+import net.demilich.metastone.game.decks.DeckFormat;
 
 public class FilterCardsCommand extends SimpleCommand<GameNotification> {
+
+	private static List<Card> filterByFormat(List<Card> collection, DeckFormat format) {
+		if (format == null) {
+			return collection;
+		}
+
+		collection.removeIf(card -> !format.isInFormat(card));
+		return collection;
+	}
 
 	private static List<Card> filterBySet(List<Card> collection, CardSet set) {
 		if (set == CardSet.ANY) {
@@ -37,6 +47,7 @@ public class FilterCardsCommand extends SimpleCommand<GameNotification> {
 		DeckProxy deckProxy = (DeckProxy) getFacade().retrieveProxy(DeckProxy.NAME);
 
 		List<Card> cards = deckProxy.getCards(deckProxy.getActiveDeck().getHeroClass());
+		cards = filterByFormat(cards, filter.getFormat());
 		cards = filterBySet(cards, filter.getSet());
 		cards = filterByText(cards, filter.getText());
 

--- a/app/src/main/java/net/demilich/metastone/gui/gameconfig/PlayerConfigView.java
+++ b/app/src/main/java/net/demilich/metastone/gui/gameconfig/PlayerConfigView.java
@@ -99,7 +99,7 @@ public class PlayerConfigView extends VBox {
 				if (deck.getHeroClass() != HeroClass.DECK_COLLECTION) {
 					continue;
 				}
-				if (deckFormat != null && deckFormat.inSet(deck)) {
+				if (deckFormat != null && deckFormat.isInFormat(deck)) {
 					deckList.add(deck);
 				}
 			}
@@ -111,7 +111,7 @@ public class PlayerConfigView extends VBox {
 					continue;
 				}
 				if (deck.getHeroClass() == heroClass || deck.getHeroClass() == HeroClass.ANY) {
-					if (deckFormat != null && deckFormat.inSet(deck)) {
+					if (deckFormat != null && deckFormat.isInFormat(deck)) {
 						deckList.add(deck);
 					}
 				}

--- a/app/src/main/resources/fxml/CardFilterView.fxml
+++ b/app/src/main/resources/fxml/CardFilterView.fxml
@@ -29,6 +29,9 @@
             <Insets />
          </opaqueInsets>
       </HBox>
-      <ComboBox fx:id="cardSetBox" prefWidth="150.0" />
+      <VBox>
+        <ComboBox fx:id="cardSetBox" prefWidth="150.0" />
+        <ComboBox fx:id="deckFormatBox" prefWidth="150.0" />
+      </VBox>
    </children>
 </fx:root>

--- a/game/src/main/java/net/demilich/metastone/game/cards/CardCatalogue.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/CardCatalogue.java
@@ -21,7 +21,6 @@ import net.demilich.metastone.utils.MetastoneProperties;
 import net.demilich.metastone.utils.ResourceInputStream;
 import net.demilich.metastone.utils.ResourceLoader;
 import net.demilich.metastone.utils.UserHomeMetastone;
-import net.demilich.metastone.utils.VersionInfo;
 
 public class CardCatalogue {
 
@@ -93,7 +92,7 @@ public class CardCatalogue {
 	public static CardCollection query(DeckFormat deckFormat, CardType cardType, Rarity rarity, HeroClass heroClass, Attribute tag) {
 		CardCollection result = new CardCollection();
 		for (Card card : cards) {
-			if (!deckFormat.inSet(card)) {
+			if (!deckFormat.isInFormat(card)) {
 				continue;
 			}
 			if (!card.isCollectible()) {
@@ -124,7 +123,7 @@ public class CardCatalogue {
 	public static CardCollection query(DeckFormat deckFormat, Predicate<Card> filter) {
 		CardCollection result = new CardCollection();
 		for (Card card : cards) {
-			if (deckFormat != null && !deckFormat.inSet(card)) {
+			if (deckFormat != null && !deckFormat.isInFormat(card)) {
 				continue;
 			}
 			if (filter.test(card)) {

--- a/game/src/main/java/net/demilich/metastone/game/decks/DeckFormat.java
+++ b/game/src/main/java/net/demilich/metastone/game/decks/DeckFormat.java
@@ -20,20 +20,28 @@ public class DeckFormat {
 		sets.add(cardSet);
 	}
 
-	public boolean inSet(Deck deck) {
+	public boolean isInFormat(Card card) {
+		if (sets.contains(card.getCardSet())) {
+			return true;
+		}
+		return false;
+	}
+
+	public boolean isInFormat(CardSet set) {
+		return sets.contains(set);
+	}
+
+	public boolean isInFormat(Deck deck) {
 		for (Card card : deck.getCards()) {
-			if (!sets.contains(card.getCardSet())) {
+			if (!isInFormat(card)) {
 				return false;
 			}
 		}
 		return true;
 	}
 
-	public boolean inSet(Card card) {
-		if (sets.contains(card.getCardSet())) {
-			return true;
-		}
-		return false;
+	public List<CardSet> getCardSets() {
+		return new ArrayList<CardSet>(sets);
 	}
 
 	public String getName() {


### PR DESCRIPTION
- Changed a few methods in DeckFormat to be more logical.
- Added Deck Formats to Deck Builder.
 - Deck Formats change which cards are available for that format, as well as which sets are used in the format.
- Left usable format to allow sorting in the Deck List view so that decks can be sorted from there.
- Fixes #246 (Or at least the parts that will be fixed for now.)