### PR TITLE
Bug Fixes

### DIFF
--- a/app/src/main/java/net/demilich/metastone/gui/simulationmode/SimulationResultView.java
+++ b/app/src/main/java/net/demilich/metastone/gui/simulationmode/SimulationResultView.java
@@ -23,6 +23,7 @@ import net.demilich.metastone.GameNotification;
 import net.demilich.metastone.game.cards.Card;
 import net.demilich.metastone.game.cards.CardCatalogue;
 import net.demilich.metastone.game.cards.CardType;
+import net.demilich.metastone.game.logic.GameLogic;
 import net.demilich.metastone.game.statistics.GameStatistics;
 import net.demilich.metastone.game.statistics.Statistic;
 
@@ -123,7 +124,7 @@ public class SimulationResultView extends BorderPane {
 	private String getFavouriteCardName(GameStatistics stats, CardType cardType) {
 		List<Card> cards = new ArrayList<Card>();
 		for (String cardId : stats.getCardsPlayed().keySet()) {
-			if (cardId.startsWith("temp_card_name_")) {
+			if (cardId.startsWith(GameLogic.TEMP_CARD_LABEL)) {
 				continue;
 			}
 			Card card = CardCatalogue.getCardById(cardId);

--- a/cards/src/main/resources/cards/basic/hunter/spell_multi-shot.json
+++ b/cards/src/main/resources/cards/basic/hunter/spell_multi-shot.json
@@ -8,9 +8,13 @@
 	"description": "Deal 3 damage to two random enemy minions.",
 	"targetSelection": "NONE",
 	"spell": {
-		"class": "MultiTargetDamageSpell",
-		"value": 3,
-		"howMany": 2
+		"class": "MultiTargetSpell",
+		"target": "ENEMY_MINIONS",
+		"value": 2,
+		"spell": {
+			"class": "DamageSpell",
+			"value": 3
+		}
 	},
 	"condition": {
 		"class": "MinionCountCondition",

--- a/cards/src/main/resources/cards/basic/warrior/spell_cleave.json
+++ b/cards/src/main/resources/cards/basic/warrior/spell_cleave.json
@@ -8,9 +8,13 @@
 	"description": "Deal 2 damage to two random enemy minions.",
 	"targetSelection": "NONE",
 	"spell": {
-		"class": "MultiTargetDamageSpell",
+		"class": "MultiTargetSpell",
+		"target": "ENEMY_MINIONS",
 		"value": 2,
-		"howMany": 2
+		"spell": {
+			"class": "DamageSpell",
+			"value": 2
+		}
 	},
 	"condition": {
 		"class": "MinionCountCondition",

--- a/cards/src/main/resources/cards/classic/neutral/minion_knife_juggler.json
+++ b/cards/src/main/resources/cards/classic/neutral/minion_knife_juggler.json
@@ -11,7 +11,8 @@
 	"trigger": {
 		"eventTrigger": {
 			"class": "AfterMinionSummonedTrigger",
-			"targetPlayer": "SELF"
+			"targetPlayer": "SELF",
+			"hostTargetType": "IGNORE_AS_TARGET"
 		},
 		"spell": {
 			"class": "MissilesSpell",

--- a/cards/src/main/resources/cards/classic/shaman/spell_forked_lightning.json
+++ b/cards/src/main/resources/cards/classic/shaman/spell_forked_lightning.json
@@ -8,9 +8,13 @@
 	"description": "Deal 2 damage to 2 random enemy minions. Overload: (2)",
 	"targetSelection": "NONE",
 	"spell": {
-		"class": "MultiTargetDamageSpell",
+		"class": "MultiTargetSpell",
+		"target": "ENEMY_MINIONS",
 		"value": 2,
-		"howMany": 2
+		"spell": {
+			"class": "DamageSpell",
+			"value": 2
+		}
 	},
 	"condition": {
 		"class": "MinionCountCondition",

--- a/cards/src/main/resources/cards/mean_streets_of_gadgetzan/hunter/spell_smugglers_crate.json
+++ b/cards/src/main/resources/cards/mean_streets_of_gadgetzan/hunter/spell_smugglers_crate.json
@@ -4,7 +4,7 @@
 	"type": "SPELL",
 	"heroClass": "HUNTER",
 	"rarity": "COMMON",
-	"description": "Give a random Beast in your hand gain +2/+2.",
+	"description": "Give a random Beast in your hand +2/+2.",
 	"targetSelection": "NONE",
 	"spell": {
 		"class": "BuffSpell",

--- a/cards/src/main/resources/cards/mean_streets_of_gadgetzan/kabal/minion_kazakus.json
+++ b/cards/src/main/resources/cards/mean_streets_of_gadgetzan/kabal/minion_kazakus.json
@@ -26,15 +26,6 @@
 					"mana": 1,
 					"spells": [
 						{
-							"class": "BuffSpell",
-							"name": "Goldthorn",
-							"description": "Give your minions +2 Health.",
-							"targetSelection": "NONE",
-							"cardDescType": "SPELL",
-							"target": "FRIENDLY_MINIONS",
-							"hpBonus": 2
-						},
-						{
 							"class": "DamageSpell",
 							"name": "Felbloom",
 							"description": "Deal 2 damage to all minions.",
@@ -76,6 +67,15 @@
 							"targetSelection": "NONE",
 							"cardDescType": "SPELL",
 							"card": "token_lesser_demon"
+						},
+						{
+							"class": "BuffSpell",
+							"name": "Goldthorn",
+							"description": "Give your minions +2 Health.",
+							"targetSelection": "NONE",
+							"cardDescType": "SPELL",
+							"target": "FRIENDLY_MINIONS",
+							"hpBonus": 2
 						},
 						{
 							"class": "BuffHeroSpell",
@@ -127,15 +127,6 @@
 							"randomTarget": true
 						},
 						{
-							"class": "BuffSpell",
-							"name": "Goldthorn",
-							"description": "Give your minions +4 Health.",
-							"targetSelection": "NONE",
-							"cardDescType": "SPELL",
-							"target": "FRIENDLY_MINIONS",
-							"hpBonus": 4
-						},
-						{
 							"class": "DamageSpell",
 							"name": "Felbloom",
 							"description": "Deal 4 damage to all minions.",
@@ -180,6 +171,15 @@
 							"targetSelection": "NONE",
 							"cardDescType": "SPELL",
 							"card": "token_greater_demon"
+						},
+						{
+							"class": "BuffSpell",
+							"name": "Goldthorn",
+							"description": "Give your minions +4 Health.",
+							"targetSelection": "NONE",
+							"cardDescType": "SPELL",
+							"target": "FRIENDLY_MINIONS",
+							"hpBonus": 4
 						},
 						{
 							"class": "BuffHeroSpell",
@@ -231,15 +231,6 @@
 							"card": "token_sheep"
 						},
 						{
-							"class": "BuffSpell",
-							"name": "Goldthorn",
-							"description": "Give your minions +6 Health.",
-							"targetSelection": "NONE",
-							"cardDescType": "SPELL",
-							"target": "FRIENDLY_MINIONS",
-							"hpBonus": 6
-						},
-						{
 							"class": "DamageSpell",
 							"name": "Felbloom",
 							"description": "Deal 6 damage to all minions.",
@@ -284,6 +275,15 @@
 							"targetSelection": "NONE",
 							"cardDescType": "SPELL",
 							"card": "token_superior_demon"
+						},
+						{
+							"class": "BuffSpell",
+							"name": "Goldthorn",
+							"description": "Give your minions +6 Health.",
+							"targetSelection": "NONE",
+							"cardDescType": "SPELL",
+							"target": "FRIENDLY_MINIONS",
+							"hpBonus": 6
 						},
 						{
 							"class": "BuffHeroSpell",

--- a/cards/src/main/resources/cards/the_grand_tournament/warlock/spell_dark_bargain.json
+++ b/cards/src/main/resources/cards/the_grand_tournament/warlock/spell_dark_bargain.json
@@ -8,29 +8,12 @@
 	"description": "Destroy 2 random enemy minions. Discard 2 random cards.",
 	"targetSelection": "NONE",
 	"spell": {
-		"class": "MetaSpell",
-		"spells": [
-			{
-				"class": "DestroySpell",
-				"target": "ENEMY_MINIONS",
-				"randomTarget": true
-			},
-			{
-				"class": "DestroySpell",
-				"target": "ENEMY_MINIONS",
-				"randomTarget": true,
-				"filter": {
-					"class": "AttributeFilter",
-					"attribute": "DESTROYED",
-					"operation": "HAS",
-					"invert": true
-				}
-			},
-			{
-				"class": "DiscardSpell",
-				"value": 2
-			}
-		]
+		"class": "MultiTargetSpell",
+		"target": "ENEMY_MINIONS",
+		"value": 2,
+		"spell": {
+			"class": "DestroySpell"
+		}
 	},
 	"condition": {
 		"class": "MinionCountCondition",

--- a/cards/src/main/resources/cards/the_old_gods/warlock/minion_darkshire_councilman.json
+++ b/cards/src/main/resources/cards/the_old_gods/warlock/minion_darkshire_councilman.json
@@ -11,7 +11,8 @@
 	"trigger": {
 		"eventTrigger": {
 			"class": "AfterMinionSummonedTrigger",
-			"targetPlayer": "SELF"
+			"targetPlayer": "SELF",
+			"hostTargetType": "IGNORE_AS_TARGET"
 		},
 		"spell": {
 			"class": "BuffSpell",

--- a/game/src/main/java/net/demilich/metastone/game/Player.java
+++ b/game/src/main/java/net/demilich/metastone/game/Player.java
@@ -3,6 +3,7 @@ package net.demilich.metastone.game;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import net.demilich.metastone.game.behaviour.IBehaviour;
 import net.demilich.metastone.game.behaviour.human.HumanBehaviour;
@@ -43,12 +44,11 @@ public class Player extends Entity {
 		this.deckName = otherPlayer.getDeckName();
 		this.setHero(otherPlayer.getHero().clone());
 		this.deck = otherPlayer.getDeck().clone();
-		for (Minion minion : otherPlayer.getMinions()) {
-			minions.add(minion.clone());
-		}
-		this.hand.addAll(otherPlayer.hand);
-		this.graveyard.addAll(otherPlayer.graveyard);
-		this.setAsideZone.addAll(otherPlayer.setAsideZone);
+		this.attributes.putAll(otherPlayer.getAttributes());
+		this.hand.addAll(otherPlayer.getHand().clone());
+		this.minions.addAll(otherPlayer.getMinions().stream().map(Minion::clone).collect(Collectors.toList()));
+		this.graveyard.addAll(otherPlayer.getGraveyard().stream().map(Entity::clone).collect(Collectors.toList()));
+		this.setAsideZone.addAll(otherPlayer.getSetAsideZone().stream().map(Entity::clone).collect(Collectors.toList()));
 		this.secrets.addAll(otherPlayer.secrets);
 		this.setId(otherPlayer.getId());
 		this.mana = otherPlayer.mana;

--- a/game/src/main/java/net/demilich/metastone/game/behaviour/threat/GameStateValueBehaviour.java
+++ b/game/src/main/java/net/demilich/metastone/game/behaviour/threat/GameStateValueBehaviour.java
@@ -95,8 +95,10 @@ public class GameStateValueBehaviour extends Behaviour {
 
 		int depth = 2;
 		// when evaluating battlecry and discover actions, only optimize the immediate value
-		if (validActions.get(0).getActionType() == ActionType.BATTLECRY || validActions.get(0).getActionType() == ActionType.DISCOVER) {
+		if (validActions.get(0).getActionType() == ActionType.BATTLECRY) {
 			depth = 0;
+		} else if (validActions.get(0).getActionType() == ActionType.DISCOVER) {
+			return validActions.get(0);
 		}
 
 		GameAction bestAction = validActions.get(0);

--- a/game/src/main/java/net/demilich/metastone/game/spells/SpellUtils.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/SpellUtils.java
@@ -107,8 +107,7 @@ public class SpellUtils {
 			return null;
 		}
 		
-		if (context.getLogic().attributeExists(Attribute.ALL_RANDOM_FINAL_DESTINATION) ||
-				context.getLogic().attributeExists(Attribute.ALL_RANDOM_FINAL_DESTINATION)) {
+		if (context.getLogic().attributeExists(Attribute.ALL_RANDOM_YOGG_ONLY_FINAL_DESTINATION)) {
 			return (DiscoverAction) discoverActions.get(context.getLogic().random(discoverActions.size()));
 		} else {
 			return (DiscoverAction) player.getBehaviour().requestAction(context, player, discoverActions);
@@ -125,8 +124,7 @@ public class SpellUtils {
 			discoverActions.add(discover);
 		}
 		
-		if (context.getLogic().attributeExists(Attribute.ALL_RANDOM_FINAL_DESTINATION) ||
-				context.getLogic().attributeExists(Attribute.ALL_RANDOM_FINAL_DESTINATION)) {
+		if (context.getLogic().attributeExists(Attribute.ALL_RANDOM_YOGG_ONLY_FINAL_DESTINATION)) {
 			return (DiscoverAction) discoverActions.get(context.getLogic().random(discoverActions.size()));
 		} else {
 			return (DiscoverAction) player.getBehaviour().requestAction(context, player, discoverActions);

--- a/game/src/main/java/net/demilich/metastone/game/spells/aura/Aura.java
+++ b/game/src/main/java/net/demilich/metastone/game/spells/aura/Aura.java
@@ -52,11 +52,6 @@ public class Aura extends SpellTrigger {
 		if (target.getReference().equals(getHostReference())) {
 			return false;
 		}
-
-		Actor targetActor = (Actor) target;
-		if (targetActor.isDestroyed()) {
-			return false;
-		}
 		
 		if (getEntityFilter() != null && !getEntityFilter().matches(context, player, target)) {
 			return false;


### PR DESCRIPTION
Fixes:
- Fixed a bug where Mind Control Tech could steal minions when below four.
- Fixed a bug where Auras didn't apply to minions with less than 0 hp. (Fixes #287)
- "Fixed" a bug where Discover Actions AI scoring crashed the game. (Fixes #297)
- Fixed Knife Juggler and Darkshire Councilman from activating their effects on themselves.
- Fixed a grammar error in Smuggler's Crate. (Fixes #298)
- Reordered the HP bonus in Kazakus' spells to be more correct.
- Fixed a bug where Noggenfogger incorrectly chose Discover actions for you.

Updates:
- Updated Player cloning code to properly clone all objects. (Fixes #300)