### PR TITLE
Added support for custom Hero and Hero Power textures

### DIFF
--- a/app/src/main/java/net/demilich/metastone/gui/IconFactory.java
+++ b/app/src/main/java/net/demilich/metastone/gui/IconFactory.java
@@ -48,80 +48,101 @@ public class IconFactory {
 
 	public static String getHeroIconUrl(HeroClass heroClass) {
 		String iconPath = RESOURCE_PATH + "/img/heroes/";
-		switch (heroClass) {
-		case DRUID:
-			iconPath += "malfurion";
-			break;
-		case HUNTER:
-			iconPath += "rexxar";
-			break;
-		case MAGE:
-			iconPath += "jaina";
-			break;
-		case PALADIN:
-			iconPath += "uther";
-			break;
-		case PRIEST:
-			iconPath += "anduin";
-			break;
-		case ROGUE:
-			iconPath += "valeera";
-			break;
-		case SHAMAN:
-			iconPath += "thrall";
-			break;
-		case WARLOCK:
-			iconPath += "guldan";
-			break;
-		case WARRIOR:
-			iconPath += "garrosh";
-			break;
-		default:
-		case ANY:
-			iconPath += "unknown";
-			break;
-
+		if (((HeroCard)hero.getSourceCard()).getAsset().equals("<Def>")){
+			switch (hero.getHeroClass()) {
+			case DRUID:
+				iconPath += "malfurion";
+				break;
+			case HUNTER:
+				iconPath += "rexxar";
+				break;
+			case MAGE:
+				iconPath += "jaina";
+				break;
+			case PALADIN:
+				iconPath += "uther";
+				break;
+			case PRIEST:
+				iconPath += "anduin";
+				break;
+			case ROGUE:
+				iconPath += "valeera";
+				break;
+			case SHAMAN:
+				iconPath += "thrall";
+				break;
+			case WARLOCK:
+				iconPath += "guldan";
+				break;
+			case WARRIOR:
+				iconPath += "garrosh";
+				break;
+			default:
+			case ANY:
+				iconPath += "unknown";
+				break;
+	
+			}
+			return iconPath + ".png";
+		} else {
+			String assetsFolder = UserHomeMetastone.getPath().replace("\\\\", "/") + "/" + "assets";
+			String pth = assetsFolder + "/" + ((HeroCard)hero.getSourceCard()).getAsset() + ".png";
+			try {
+				return new File(pth).toURI().toURL().toString();
+			} catch (MalformedURLException e) {
+				return pth;
+			}
 		}
-		return iconPath + ".png";
 	}
 
 	public static String getHeroPowerIconUrl(HeroPower heroPower) {
-		String iconPath = RESOURCE_PATH + "/img/powers/";
-		switch (heroPower.getHeroClass()) {
-		case DRUID:
-			iconPath += "shapeshift";
-			break;
-		case HUNTER:
-			iconPath += "steady_shot";
-			break;
-		case MAGE:
-			iconPath += "fireblast";
-			break;
-		case PALADIN:
-			iconPath += "reinforce";
-			break;
-		case PRIEST:
-			iconPath += "lesser_heal";
-			break;
-		case ROGUE:
-			iconPath += "dagger_mastery";
-			break;
-		case SHAMAN:
-			iconPath += "totemic_call";
-			break;
-		case WARLOCK:
-			iconPath += "life_tap";
-			break;
-		case WARRIOR:
-			iconPath += "armor_up";
-			break;
-		default:
-			iconPath += "unknown";
-			break;
-
+		if (heroPower.getAsset().equals("<Def>")){
+			String iconPath = RESOURCE_PATH + "/img/powers/";
+			
+			switch (heroPower.getHeroClass()) {
+			case DRUID:
+				iconPath += "shapeshift";
+				break;
+			case HUNTER:
+				iconPath += "steady_shot";
+				break;
+			case MAGE:
+				iconPath += "fireblast";
+				break;
+			case PALADIN:
+				iconPath += "reinforce";
+				break;
+			case PRIEST:
+				iconPath += "lesser_heal";
+				break;
+			case ROGUE:
+				iconPath += "dagger_mastery";
+				break;
+			case SHAMAN:
+				iconPath += "totemic_call";
+				break;
+			case WARLOCK:
+				iconPath += "life_tap";
+				break;
+			case WARRIOR:
+				iconPath += "armor_up";
+				break;
+			default:
+				iconPath += "unknown";
+				break;
+	
+			}
+			iconPath += ".png";
+			return iconPath;
+		} else {
+			String assetsFolder = UserHomeMetastone.getPath().replace("\\\\", "/") + "/" + "assets";
+			String pth = assetsFolder + "/" + heroPower.getAsset() + ".png";
+			try {
+				return new File(pth).toURI().toURL().toString();
+			} catch (MalformedURLException e) {
+				return pth;
+			}
 		}
-		iconPath += ".png";
-		return iconPath;
 	}
 
 	public static String getImageUrl(String imageName) {

--- a/game/src/main/java/net/demilich/metastone/game/cards/HeroCard.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/HeroCard.java
@@ -20,6 +20,7 @@ public class HeroCard extends Card {
 	public HeroCard(HeroCardDesc desc) {
 		super(desc);
 		setAttribute(Attribute.BASE_HP, getAttributeValue(Attribute.MAX_HP));
+		if (desc.asset == null) desc.asset = "<Def>";
 		this.desc = desc;
 	}
 
@@ -38,6 +39,10 @@ public class HeroCard extends Card {
 	@Override
 	public PlayCardAction play() {
 		throw new UnsupportedOperationException("Hero cards cannot be played");
+	}
+	
+	public String getAsset(){
+		return desc.asset;
 	}
 
 }

--- a/game/src/main/java/net/demilich/metastone/game/cards/desc/HeroCardDesc.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/desc/HeroCardDesc.java
@@ -8,6 +8,7 @@ public class HeroCardDesc extends CardDesc {
 
 	public String heroPower;
 	public Race race = Race.NONE;
+	public String asset;
 
 	@Override
 	public Card createInstance() {

--- a/game/src/main/java/net/demilich/metastone/game/cards/desc/HeroPowerCardDesc.java
+++ b/game/src/main/java/net/demilich/metastone/game/cards/desc/HeroPowerCardDesc.java
@@ -8,6 +8,7 @@ public class HeroPowerCardDesc extends SpellCardDesc {
 	
 	public String[] options;
 	public String bothOptions;
+	public String asset;
 
 	@Override
 	public Card createInstance() {

--- a/game/src/main/java/net/demilich/metastone/game/heroes/powers/HeroPower.java
+++ b/game/src/main/java/net/demilich/metastone/game/heroes/powers/HeroPower.java
@@ -11,10 +11,12 @@ import net.demilich.metastone.game.targeting.CardLocation;
 public class HeroPower extends SpellCard {
 
 	private int used;
+	private String asset;
 
 	public HeroPower(HeroPowerCardDesc desc) {
 		super(desc);
 		setLocation(CardLocation.HERO_POWER);
+		asset = (desc.asset == null ? "<Def>" : desc.asset);
 	}
 
 	public int hasBeenUsed() {
@@ -36,6 +38,10 @@ public class HeroPower extends SpellCard {
 	
 	public void setUsed(int used) {
 		this.used = used;
+	}
+	
+	public String getAsset(){
+		return asset;
 	}
 
 }


### PR DESCRIPTION
This is one of the few gui tweaks I had on my local version - it takes textures from the <metastone_folder>/assets and loads them.
Keep in mind that it does not break any cards - when there isn't any texture given it's going to use the basic hero power texture of the played class.

Here's an example for an updated Jaraxxus card code:


	"name": "Lord Jaraxxus",
	"baseManaCost": 9,
	"heroPower": "hero_power_inferno",
	"type": "HERO",
	"asset": "jaraxxus",
	"heroClass": "WARLOCK",
	"rarity": "LEGENDARY",
	"race": "DEMON",
	"attributes": {
		"HP": 15,
		"MAX_HP": 15
	},
	"collectible": false,
	"set": "CLASSIC",
	"fileFormatVersion": 1


Pretty much the same as it used to be with the additional **"asset": "jaraxxus"** line which points to <metastone_folder>/assets/jaraxxus.png
