### PR TITLE
Fixed javafx dependencies in app/build.gradle #380

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,15 @@
 apply plugin: 'java'
 apply plugin: 'application'
-apply from: 'javafx.plugin'
+apply plugin: 'javafx-gradle-plugin'
+
+buildscript {
+    dependencies {
+        classpath group: 'de.dynamicfiles.projects.gradle.plugins', name: 'javafx-gradle-plugin', version: '8.8.2'
+    }
+    repositories {
+        jcenter()
+    }
+}
 
 mainClassName = 'net.demilich.metastone.MetaStone'
 
@@ -22,9 +31,12 @@ dependencies {
 	testCompile group: 'org.testng', name: 'testng', version: '6.+'
 }
 
-javafx {
-	appName rootProject.name
-	mainClass = mainClassName
+jfx {
+    // minimal requirement for jfxJar-task
+    mainClass = 'JavaFXDemo'
+    
+    // minimal requirement for jfxNative-task
+    vendor = ''
 }
 
 test {


### PR DESCRIPTION
I changed the app/build.gradle with the information i found [here](https://github.com/eclipse/buildship/issues/573). I can now execute _./gradlew run_ and _./gradlew idea_ to do a setup in IntelliJ on my MacOS system. This fix should also work on Windows.